### PR TITLE
fix(webpack): close(#71): Enable hot module replacement for .coffee files

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "nib": "^1.1.0",
     "node-sass": "^3.3.3",
     "phantomjs": "^1.9.18",
+    "react-hot-loader": "^1.3.0",
     "redux-devtools": "^2.1.3",
     "sass-loader": "^2.0.1",
     "style-loader": "^0.12.4",

--- a/webpack.config.coffee
+++ b/webpack.config.coffee
@@ -20,7 +20,7 @@ config =
     loaders: [
       {
         test:   /\.coffee$/,
-        loader: "coffee"
+        loader: "react-hot!coffee"
       }
       {
         test:   /\.css$/,


### PR DESCRIPTION
This commit makes development more efficient as it enables hot module replacement. Therefor not the whole Javascript bundle is exchanged but only the effected one and in such that the page does not (seem) to reload.
