### PR TITLE
fix(map): Firefox hides searchbar

### DIFF
--- a/src/components/App.styl
+++ b/src/components/App.styl
@@ -64,7 +64,6 @@ button.pure-button i
       flex 1
 
     .left
-      order -1
       max-height     100vh
       overflow-y     hidden
       display        flex


### PR DESCRIPTION
Close #77

It seems that the css attribute "order: -1" is interpreted differently
from chrome and firefox. Firefox does not show the searchpanel if order
is set (to -1).
