### PR TITLE
auto disable cache for new releases

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -17,7 +17,7 @@ const config = {
   },
   output: {
     path: path.join(__dirname, 'dist/'),
-    filename: "[name].js"
+    filename: "[name].js?hash=[hash]"
   },
   devServer: {
     hot: true,


### PR DESCRIPTION
closes #160
If this still does not work we should add the hashes to the filenames:
https://webpack.js.org/guides/caching/