### PR TITLE
Extended search results

### DIFF
--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -36,6 +36,7 @@ module.exports = {
       })
       .query((cats.length > 0) ? ('categories=' + cats.join(',')) : "")
       .query('bbox=' + bbox.join(','))
+      .query('limit=250') // TODO: Replace with constant or parameter
       .set('Accept', 'application/json')
       .end(jsonCallback(cb));
   },

--- a/src/constants/Search.js
+++ b/src/constants/Search.js
@@ -1,6 +1,6 @@
 module.exports = {
   CITY_SEARCH_RESULTS_MIN_DISTANCE: 0.3,
   CITY_SEARCH_RESULTS_MIN_IMPORTANCE: 0.5,
-  NUM_ENTRIES_TO_FETCH: 35,
+  NUM_ENTRIES_TO_FETCH: 50, // includes both visible + invisible entries
   NUM_ENTRIES_TO_SHOW: 35 // after a few searches we will have loaded n * NUM_ENTRIES_TO_FETCH, that's why we need this extra limit
 };


### PR DESCRIPTION
* Explicitly request 250 entries at once when searching (default: 100)
* Fetch more entries per request to account for invisible entries