### PR TITLE
fixes #541 - small village scharnstein was not shown in search result

### DIFF
--- a/src/constants/Search.js
+++ b/src/constants/Search.js
@@ -1,6 +1,6 @@
 module.exports = {
   CITY_SEARCH_RESULTS_MIN_DISTANCE: 0.3,
-  CITY_SEARCH_RESULTS_MIN_IMPORTANCE: 0.5,
+  CITY_SEARCH_RESULTS_MIN_IMPORTANCE: 0.48,
   NUM_ENTRIES_TO_FETCH: 35,
   NUM_ENTRIES_TO_SHOW: 35 // after a few searches we will have loaded n * NUM_ENTRIES_TO_FETCH, that's why we need this extra limit
 };


### PR DESCRIPTION
Scharnstein hatte folgende Response:

[{"place_id":198018021,"licence":"Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright","osm_type":"relation","osm_id":60621,"boundingbox":["47.8546368","47.9481996","13.8714442","13.9943598"],"lat":"47.904491","lon":"13.9609752","display_name":"Scharnstein, Gmunden, Oberösterreich, 4644, Österreich","class":"boundary","type":"administrative","importance":0.48036014761660606,"icon":"https://nominatim.openstreetmap.org/images/mapicons/poi_boundary_administrative.p.20.png","address":{"city":"Scharnstein","county":"Gmunden","state":"Oberösterreich","postcode":"4644","country":"Österreich","country_code":"at"}}]

CITY_SEARCH_RESULTS_MIN_IMPORTANCE war zu gering, deswegen wurde der Ort im Dropdown nicht angezeigt.