### PR TITLE
Registrierungshinsweis

### DIFF
--- a/src/locales/translation-de.json
+++ b/src/locales/translation-de.json
@@ -97,7 +97,7 @@
 		"password1":"Passwort",
 		"password2":"Passwort wiederholen",
 		"submitButton":"Registrieren",
-		"loginText":"Du hast schon einen Account? Dann kannst du dich",
+		"loginText":"Hinweis: Der Nutzername darf keine Punkte und keine Umlaute enthalten! Das Passwort muss mindestes 8 Zeichen haben, aber auch keine Umlaute, oder Sonderzeichen. Pro Account (Nutzername) kann nur eine Region abonniert werden. Pro Mailadresse können aber mehrere Accounts mit unterschiedlichen Nutzernamen erstellt werden.    --> Du hast schon einen Account? Dann kannst du dich",
 		"loginLink":"hier einloggen",
 		"requiredField":"Pflichtangabe",
 		"invalidValues":"Ungültige Daten",


### PR DESCRIPTION
Habe folgenden Hinweise unter dem Registrierungsfeld eingefügt: "Der Nutzername darf keine Punkte und keine Umlaute enthalten! Das Passwort muss mindestes 8 Zeichen haben, aber auch keine Umlaute, oder Sonderzeichen. Pro Account (Nutzername) kann nur eine Region abonniert werden. Pro Mailadresse können aber mehrere Accounts mit unterschiedlichen Nutzernamen erstellt werden. "

Optimalerweise würde dieser Hinweis aber über den Eingabefeldern, direkt unter der Überschrift "Registrieren" stehen.