### PR TITLE
Local development & Getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ that are referenced from the frontend by their ids.
 
 For this purpose start your favourite SQLite3 management tool, open the *openfairdb.db* file
 and execute the SQL statements in
-[openfairdb/init_categories_de.sql](openfairdb/init_categories_de.sql). You can also accomplish
+[res/init_openfairdb_categories_de.sql](res/init_openfairdb_categories_de.sql). You can also accomplish
 this task with the SQLite CLI tool:
 
     ```sh

--- a/README.md
+++ b/README.md
@@ -27,51 +27,98 @@ To be able to start development you'll need the following tools:
 
 Now clone this repository:
 
+    ```sh
     git clone https://github.com/goodmap/goodmap
+    ```
 
 Go to the root of it and install all the dependencies:
 
+    ```sh
     cd goodmap
     yarn
+    ```
 
 ### Build
 
 To build the web application run:
 
+    ```sh
     yarn start
+    ```
 
 The result can be found in `dist/`.
 
-### Local development setup
+### Development
+
+You may either use a remote instance of the OpenFairDB server or start your
+own instance locally.
+
+#### Remote OpenFairDB server
 
 The easiest way to get a local setup running is by using the remote API of [OpenFairDB](https://github.com/slowtec/openfairdb).
 To do so change `src/constants/URLs.js` to
 
-``` js
-OFDB_API: {
-  //link: window.location.origin + "/api" //use when you run openfairdb locally
-  link: window.location.protocol + "//" + "api.ofdb.io/v0" //use this to use the remote api
-}
-```
+    ``` js
+    OFDB_API: {
+        //link: window.location.origin + "/api" //use when you run openfairdb locally
+        link: window.location.protocol + "//" + "api.ofdb.io/v0" //use this to use the remote api
+    }
+    ```
 
-The alternative is to run OpenFairDB Server locally:
+Don't forget to skip those changes later when comitting or revert them before
+starting a local server instance as described next!
 
-Download, unpack and run (on linux):
-``` sh
-wget https://download.ofdb.io/openfairdb-x86_64-linux-v0.3.1.tar.gz
-tar xzf openfairdb-x86_64-linux-v0.3.1.tar.gz
-./openfairdb
-```
-`openfairdb` should now be listening on port 6767.
-To actually get started to also need to add some [content](https://github.com/slowtec/openfairdb/issues/112#issuecomment-432724965).
+#### Local OpenFairDB server
+
+The alternative is to run [OpenFairDB](https://github.com/slowtec/openfairdb) server locally.
+A static executable for all recent versions is available on the
+[OpenFairDB *Releases*](https://github.com/slowtec/openfairdb/releases) page.
+
+Download, unpack and run (on Linux):
+
+    ```sh
+    wget https://github.com/slowtec/openfairdb/releases/download/v0.5.5/openfairdb_v0.5.5.x86_64-unknown-linux-musl.tar.xz
+    tar xJf openfairdb_v0.5.5.x86_64-unknown-linux-musl.tar.xz
+    RUST_LOG=info ROCKET_PORT=6767 ./openfairdb
+    ```
+
+`openfairdb` should be listening on port 6767. Stop the server for finishing the initial setup.
+
+##### Database setup
+
+The file `openfair.db` with an empty SQLite3 database has been created during the first startup
+in the current working directory. This empty database needs to be populated with 3 categories
+that are referenced from the frontend by their ids.
+
+For this purpose start your favourite SQLite3 management tool, open the *openfairdb.db* file
+and execute the SQL statements in
+[openfairdb/init_categories_de.sql](openfairdb/init_categories_de.sql). You can also accomplish
+this task with the SQLite CLI tool:
+
+    ```sh
+    sqlite3 openfair.db < res/init_openfairdb_categories_de.sql
+    ```
+
+The actual names of the categories in the database do not matter, but you may translate them
+into your preferred language.
+
+Now restart the server again and keep it running in a terminal to monitor the logs:
+
+    ```sh
+    RUST_LOG=info ROCKET_PORT=6767 ./openfairdb
+    ```
+
+#### Web app
 
 Get the web app running:
-``` sh
+
+    ```sh
     cd /path/to/kartevonmorgen/
     npm start
-```
-The web app is now listening on port 8080.
-Open it in your browser `http://localhost:8080`.
+    ```
+
+The web app is now listening on port 8080. Open it in your browser `https://localhost:8080`.
+Ignore the security warning that is caused by a self-signed certificate in the local proxy.
 
 On every file change in `src/`, the app will be build
 for you and the browser reloads automatically.
@@ -80,9 +127,15 @@ for you and the browser reloads automatically.
 
 To run the tests type
 
+    ```sh
     yarn test
+    ```
+
 or
+
+    ```sh
     yarn watch-test
+    ```
 
 ### Backend
 

--- a/res/init_openfairdb_categories_de.sql
+++ b/res/init_openfairdb_categories_de.sql
@@ -1,0 +1,3 @@
+INSERT OR IGNORE INTO categories (id, created, version, name) VALUES ('2cd00bebec0c48ba9db761da48678134', strftime('%s', CURRENT_TIMESTAMP), 0, 'Initiative');
+INSERT OR IGNORE INTO categories (id, created, version, name) VALUES ('c2dc278a2d6a4b9b8a50cb606fc017ed', strftime('%s', CURRENT_TIMESTAMP), 0, 'Event');
+INSERT OR IGNORE INTO categories (id, created, version, name) VALUES ('77b3c33a92554bcf8e8c2c86cedd6f6f', strftime('%s', CURRENT_TIMESTAMP), 0, 'Unternehmen');

--- a/src/constants/URLs.js
+++ b/src/constants/URLs.js
@@ -9,11 +9,11 @@ const API_VERSION = 'v0';
 const OFDB_API_LINK = (() => {
   switch (__STAGE__){
     case APP_STAGES.LOCAL:
-      return "https://nightly.ofdb.io/";
+      return "/api/";
 
     case APP_STAGES.NIGHTLY:
       return "https://nightly.ofdb.io/";
-    
+
     default:
       // production
       return "https://kartevonmorgen.org/api/";

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -21,9 +21,9 @@ const config = {
     hot: true,
     inline: true,
     proxy: {
-      "/api": {
+      "/api/v0": {
         target: "http://localhost:6767",
-        pathRewrite: {"^/api" : ""}
+        pathRewrite: {"^/api/v0" : "/api"}
       }
     }
   },


### PR DESCRIPTION
* Fixed the configuration for using a local OpenFairDB server during development
* Updated and fixed the getting started instructions
* Added instructions on how to bootstrap an empty OpenFairDB database
