### PR TITLE
README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,17 @@
-# Karte von morgen
+# Goodmap
 
-![Screenshot](https://raw.githubusercontent.com/flosse/kartevonmorgen/master/screenshot.jpg)
+Goodmap is a map platform for changemaker projects. Currently, two projects are using goodmap:
+- Transition München: Beta-Version: [https://map.transition-muc.de/](https://map.transition-muc.de/)
+- Karte von morgen: [https://kartevonmorgen.org/](https://kartevonmorgen.org/)
 
-## Mapping for Good
-
-von morgen supports kindness, sustainability and joint action.
-Everything that brings a little happiness to our world.
-We believe that living in a de‐stressed, environmental‐friendly and
-trust‐worthy society, is already in progress.
-We want to support people in finding ways to embrace those values.
-
-The Map von morgen is a website and app, that allows users to share their
-favorite places in the world. Places that are forward‐thinking and inspiring.
-The goal is to collect projects, companies and events that make a world of
-tomorrow, already experienceable today.
-
-Demo: [https://kartevonmorgen.org/](https://kartevonmorgen.org/)
-
-## Development
+Both projects are using the [https://github.com/goodmap/goodmap-webapp](goodmap-webapp) (React). And goodmap-webapp is using [https://github.com/goodmap/goodmap-core](https://github.com/goodmap/goodmap-core) (pure TypeScript, framework-agnostic).
 
 [![Build Status](https://secure.travis-ci.org/flosse/kartevonmorgen.svg?branch=master)](http://travis-ci.org/flosse/kartevonmorgen)
 [![Dependency Status](https://gemnasium.com/flosse/kartevonmorgen.svg)](https://gemnasium.com/flosse/kartevonmorgen)
 [![Dependency Status](https://dependencyci.com/github/flosse/kartevonmorgen/badge)](https://dependencyci.com/github/flosse/kartevonmorgen)
 [![License](https://img.shields.io/badge/license-AGPLv3-blue.svg?style=flat)](https://github.com/flosse/kartevonmorgen/blob/master/LICENSE)
 
-Are you're interested in contributing to KVM?
+Are you're interested in contributing?
 The following is a description of a quickstart.
 If you're looking for a more comprehensive introduction,
 have a look at [CONTRIBUTING.md](CONTRIBUTING.md).
@@ -40,18 +27,18 @@ To be able to start development you'll need the following tools:
 
 Now clone this repository:
 
-    git clone https://github.com/flosse/kartevonmorgen
+    git clone https://github.com/goodmap/goodmap
 
 Go to the root of it and install all the dependencies:
 
-    cd kartevonmorgen/
-    npm install
+    cd goodmap
+    yarn
 
 ### Build
 
 To build the web application run:
 
-    npm run pack
+    yarn start
 
 The result can be found in `dist/`.
 
@@ -91,10 +78,11 @@ for you and the browser reloads automatically.
 
 ### Tests
 
-All the tests can be found in the `spec/` folder.
 To run the tests type
 
-    npm t
+    yarn test
+or
+    yarn watch-test
 
 ### Backend
 


### PR DESCRIPTION
ich hab jetzt mal die sehr KVM-spezifischen Dinge aus der README genommen, stattdessen geschrieben dass sowohl KVM als auch Transition-MUC in diesem Repo sind, beide aber goodmap-core und goodmap-webapp verwenden.
Das wäre jetzt wahrscheinlich der nächste Schritt diese Repos auch tatsächlich zu verwenden. Wie ist da der Stand, @ingowonner ich nehme mal an ihr verwendet momentan noch "goodmap-webapp" und "goodmap-core", die als Ordner in diesem Repo liegen?
Ich wundere mich gerade auch bisschen über die Schneidung der Repos. Wenn wir schon mehrere Repos machen, macht es doch irgendwie nicht so viel Sinn wenn KVM & Transition MUC in einem repo liegen. (Hatte ich ja auch schon beim Planning vor 2 Wochen gesagt. Aber passt auch so für mich, wenn es für euch passt).

Die Hinweise zum Starten der Entwicklungsumgebung hab ich hier noch drin gelassen, auch wenn es momentan (jedenfalls auf dem develop-Branch) noch nicht so funktioniert.

(Ich hab das hier online auf Github gemacht und aus Versehen schon in Master committed. Hier ist trotzdem noch der Pull Request, den ihr gerne in Develop mergen könnt. Dann passt alles wieder)