### PR TITLE
Improve ES translation, with small correction in DE and EN

### DIFF
--- a/src/locales/translation-de.json
+++ b/src/locales/translation-de.json
@@ -11,7 +11,7 @@
     "iHaveRead": "Ich habe die",
     "creativeCommonsLicense": "Bestimmungen der Creative-Commons Lizenz CC0",
     "openDatabaseLicense": "Bestimmungen der OpenDatabase Lizenz",
-    "licenseAccepted": "gelesen und akzeptiere sie",
+    "licenseAccepted": "gelesen und akzeptiere sie.",
     "license": "Lizenz",
     "title": "Titel",
     "start": "Beginn",
@@ -21,7 +21,7 @@
     "tags": "Stichworte",
     "newTag": "Neu:",
     "noTagSuggestion": "Tippen für Vorschläge.",
-    "tagsLoading": "Vorschläge werden geladen…",
+    "tagsLoading": "Vorschläge werden geladen...",
     "contactPerson": "Kontaktperson",
     "homepage": "Homepage",
     "phone": "Telefon",
@@ -41,7 +41,7 @@
     "editEntryHeading": "Eintrag bearbeiten",
     "newEntryHeading": "Neuer Eintrag",
     "savingError": "Der Eintrag konnte nicht gespeichert werden",
-    "valueError": "Bitte überprüfen Sie ihre Eingaben.",
+    "valueError": "Bitte überprüfe deine Eingaben.",
     "requiredField": "Pflichtangabe",
     "titleTooLong": "Zu langer Titel",
     "titleTooShort": "Zu kurzer Titel",
@@ -60,7 +60,7 @@
     "acceptLicense": "Lizenzzustimmung ist nötig",
     "invalidLicenseAgreement": "Ungültige Zustimmung",
     "invalidURL": "Ungültige URL",
-    "httpMissing": "\"http://\" oder \"https://\" fehlt)",
+    "httpMissing": "\"http://\" oder \"https://\" fehlt",
     "generateHours": "Öffnungszeiten konfigurieren!"
   },
   "entryDetails": {
@@ -72,7 +72,7 @@
     "reportLink": "Diesen Eintrag melden",
     "reportSubject": "Eintrag melden",
     "reportBody": "Mit dem Eintrag {link} gibt es folgendes Problem:",
-    "readMore": "Leer más...",
+    "readMore": "Mehr lesen...",
     "lastEdit": "Letzte Änderung:",
     "today": "heute",
     "daysAgo": "Tage her",
@@ -137,12 +137,12 @@
       "solidarity": "Solidarität"
     },
     "contextExplanation": {
-      "diversity": "Ökologische Vielfalt, Artgerechte Haltung, Bio, wenige Zusatzstoffe etc.",
-      "renewable": "Umweltschutz, kurze Transportwege, effizienter/geringer Einsatz von Rohstoffen und Energie, Circular Economy etc.",
+      "diversity": "Ökologische Vielfalt, Artgerechte Haltung, Bio, wenige Zusatzstoffe, etc.",
+      "renewable": "Umweltschutz, kurze Transportwege, effizienter/geringer Einsatz von Rohstoffen und Energie, Circular Economy, etc.",
       "fairness": "Sichere, inklusive, faire und angemessene Arbeitsbedingungen in der gesamten Wertschöpfungskette.",
       "humanity": "Haben alle Beteiligten Freiraum für eigene Ideen, Weiterentwicklung und kulturelle Vielfalt? Gibt es Mitbestimmungsrechte und demokratische Prozesse?",
-      "transparency": "Sind Produktions-, Finanzierungs- und Handelsketten öffentlich nachvollziehbar? ",
-      "solidarity": "Kooperative Arbeitsweise, Finanzierung und Investitionen nachhaltig und ethisch, zugänglich für jeden Geldbeutel etc."
+      "transparency": "Sind Produktions-, Finanzierungs- und Handelsketten öffentlich nachvollziehbar?",
+      "solidarity": "Kooperative Arbeitsweise, Finanzierung und Investitionen nachhaltig und ethisch, zugänglich für jeden Geldbeutel, etc."
     },
     "valueName": {
       "minusOne": "von gestern",
@@ -166,7 +166,7 @@
     "chooseContext": "Wähle einen Aspekt der Nachhaltigkeit für deine Bewertung",
     "title": "Überschrift",
     "comment": "Kommentar/Erklärung",
-    "reference": "Quelle (z.B. einen Link oder 'ich arbeite da' etc.)",
+    "reference": "Quelle (z.B. einen Link oder 'ich arbeite da', etc.)",
     "ratingHeading": "Bewertung",
     "cancel": "abbrechen",
     "save": "bewerten",
@@ -191,7 +191,7 @@
     "changeSubscription": {
       "heading": "Dein Abonnement",
       "text1": "Du hast einen Kartenausschnitt abonniert und wirst bei neuen Einträgen und Änderungen in diesem Bereich per Email benachrichtigt.",
-      "text2": "Wenn du den abonnierten Kartenausschnitt ändern möchtest navigiere zu dem Kartenausschnitt der dich interessiert und klicke dann auf \"ändern\""
+      "text2": "Wenn du den abonnierten Kartenausschnitt ändern möchtest, navigiere zu dem Kartenausschnitt der dich interessiert und klicke dann auf \"ändern\"."
     },
     "newSubscription": {
       "heading": "Kartenausschnitt abonnieren",
@@ -269,17 +269,17 @@
       },
       "confirm-email-error": {
         "message": "Ups! Es gab einen Fehler beim Bestätigen deiner Email-Adresse. Bitte probiere, dich mit einem neuen Benutzernamen erneut zu ",
-        "link": "registrieren"
+        "link": "registrieren."
       },
       "email-confirmed": {
         "text1": "Deine Email-Adresse wurde bestätigt.",
         "text2": "Du kannst dich jetzt ",
-        "link": "anmelden"
+        "link": "anmelden."
       },
       "logged-out": "Du bist ausgeloggt."
     },
     "join": {
-      "heading": " Werde Teil unseres Teams",
+      "heading": "Werde Teil unseres Teams",
       "paragraph1": "Wir sind ein deutschlandweites Team und immer auf der Suche nach neuen Mitgliedern! Unsere aktuellen Ausschreibungen findest du hier:",
       "paragraph2": "Wir suchen Regional- und Themenpilot *innen: als direkte*r Ansprechpartner*in vor Ort, sicherst du die Qualität der Karteneinträge, organisierst z.B. Aktionen und Workshops und zeigst deine Stadt von ihrer besten Seite!",
       "paragraph3": "Du hast Fragen oder Interesse? Wir freuen uns von dir zu hören:"
@@ -389,7 +389,7 @@
       "4": "Auf unserer Website kannst du andere darauf aufmerksam machen – und dich so für einen von Menschen gestalteten Ort einsetzen, der dir persönlich am Herzen liegt.",
       "5": "Wir sind auf der Suche nach vielfältigen Ideen, Initiativen und Unternehmen, die den aktuellen sozialen, ökologischen und ökonomischen Umbrüchen alternativ entgegen wirken. Diese möchten wir vernetzten und ihnen möchten wir einen gemeinsamen Online-Auftritt und damit eine erhöhte Aufmerksamkeit ermöglichen.",
       "6": "Nach dem Wiki-Prinzip können alle Nutzer*innen, Initiativen und Unternehmen sich und andere auf der Karte eintragen und so ihre Mitmenschen erreichen. Doch von morgen ist mehr als eine Onlineplattform: Regionalpilot*innen sichern vor Ort die Qualität der Karteneinträge und haben neben einer redaktionellen Funktion die Aufgabe durch Bildungsveranstaltungen und Aktionen den regionalen Austausch zwischen Bürger*innen, Initiativen und Unternehmen zu stärken.",
-      "7": "von morgen fragt nach Werten, die unsere Gesellschaft fundieren und bewegen. Wir zeigen Menschen, die Guten tun, wo es Gutes gibt."
+      "7": "von morgen fragt nach Werten, die unsere Gesellschaft fundieren und bewegen. Wir zeigen Menschen, die Gutes tun, wo es Gutes gibt."
     },
     "heading2": "Hintergründe und Visionen",
     "text2": {
@@ -415,7 +415,7 @@
     "placeholder": "Wonach suchst du? (# für Tags)"
   },
   "resultlist": {
-    "showMoreEntries": "mehr Einträge anzeigen...",
+    "showMoreEntries": "Mehr Einträge anzeigen...",
     "entriesLoading": "Einträge werden geladen...",
     "noEntriesFound": "Es konnten keine Einträge gefunden werden.",
     "addEntry": "Eintrag hinzufügen"
@@ -425,7 +425,7 @@
     "genericError": "Ups! Es ist ein Fehler aufgetreten...",
     "subscriptionChanged": "Abonnement wurde geändert.",
     "subscriptionAdded": "Kartenausschnitt wurde abonniert.",
-    "unsubscribingSuccessfull": "Abonnement wurde abbestellt",
+    "unsubscribingSuccessfull": "Abonnement wurde abbestellt.",
     "entrySaved": "Eintrag wurde gespeichert.",
     "ratingSaved": "Bewertung wurde gespeichert.",
     "linkCopied": "Link erfolgreich in die Zwischenablage kopiert!"

--- a/src/locales/translation-en.json
+++ b/src/locales/translation-en.json
@@ -11,7 +11,7 @@
     "iHaveRead": "I have read and accept the Terms of the ",
     "creativeCommonsLicense": "Creative-Commons License CC0",
     "openDatabaseLicense": "OpenDatabase License",
-    "licenseAccepted": "",
+    "licenseAccepted": ".",
     "license": "License",
     "title": "Title",
     "start": "Start",
@@ -21,7 +21,7 @@
     "tags": "Tags",
     "newTag": "New:",
     "noTagSuggestion": "Type for sugestions.",
-    "tagsLoading": "Loading suggestions…",
+    "tagsLoading": "Loading suggestions...",
     "contactPerson": "Contact person",
     "homepage": "Homepage",
     "phone": "Phone",
@@ -137,11 +137,11 @@
       "solidarity": "Solidarity"
     },
     "contextExplanation": {
-      "diversity": "Ecological diversity, organic certifications, few additives etc.",
-      "renewable": "Environmental protection, short transport routes, efficient/ low use of resources and energy, circular economy etc.",
+      "diversity": "Ecological diversity, animal welfare, organic certifications, few additives, etc.",
+      "renewable": "Environmental protection, short transport routes, efficient/ low use of resources and energy, circular economy, etc.",
       "fairness": "Safe, inclusive, fair and appropriate working conditions throughout the entire value chain.",
       "humanity": "Do all participants have room for their own ideas, further development and cultural diversity? Are there rights to participate and democratic processes?",
-      "transparency": "Are production, financing and retail-chains publicly comprehensible? ",
+      "transparency": "Are production, financing and retail-chains publicly comprehensible?",
       "solidarity": "Cooperative working, sustainable and ethical financing and investments, in consideration of all consumer budgets, etc."
     },
     "valueName": {
@@ -166,7 +166,7 @@
     "chooseContext": "Choose a sustainability criteria to rate",
     "title": "Title",
     "comment": "Comment/Explanation",
-    "reference": "Reference (e.g. a link or \"I work there.\" etc.)",
+    "reference": "Reference (e.g. a link or \"I work there.\", etc.)",
     "ratingHeading": "Rating",
     "cancel": "cancel",
     "save": "save rating",
@@ -180,7 +180,7 @@
     "commentTooLong": "Comment too long",
     "commentTooShort": "Comment too short",
     "maxNumCharactersComment": "out of max. 500 characters",
-    "minNumCharactersComment": "characters, min: 10"
+    "minNumCharactersComment": "characters, minimum 10"
   },
   "commentForm": {
     "chooseContext": "Add your rating to the following sustainability criterion of this entry",
@@ -191,7 +191,7 @@
     "changeSubscription": {
       "heading": "Your subscription",
       "text1": "You have subscribed to a map section and will be notified by email of new entries and changes within this area.",
-      "text2": "If you want to change the subscribed map section, navigate to the map section you are interested in and then click on \"change\""
+      "text2": "If you want to change the subscribed map section, navigate to the map section you are interested in and then click on \"change\"."
     },
     "newSubscription": {
       "heading": "Subscribe to map section",
@@ -225,7 +225,7 @@
     "slogan": "Mapping for Good",
     "city-search": {
       "placeholder": "Which place would you like to discover?",
-      "error": "Error while searching for cities",
+      "error": "Error while searching for cities.",
       "no-results": "Could not find any city with that name.",
       "show-map": "Show map..."
     },
@@ -273,13 +273,13 @@
       },
       "email-confirmed": {
         "text1": "Your email address has been confirmed.",
-        "text2": "You can now",
+        "text2": "You can now ",
         "link": "log in."
       },
       "logged-out": "You're logged out."
     },
     "join": {
-      "heading": "Become a part of our team.",
+      "heading": "Become a part of our team",
       "paragraph1": "We are a team across Germany and are always looking for new team members! You can find our current openings here:",
       "paragraph2": "We are looking for local scouts, that are experts to their regions or are familiar with topics of the sustainable conversation: as our direct contact locally, you will ensure the quality of the map entries, organize events and workshops and show your city from its best side!",
       "paragraph3": "Do you have any questions or did we spark your interest? We look forward to hear from you:"
@@ -330,10 +330,10 @@
     },
     "chapter5": {
       "heading": "Our team",
-      "text": "Das Team von morgen ist so bunt wie der Wandel. Ehemalige entwicklungspolitische Freiwillige, Studierende, Wandelgestalter*innen und Stipendiaten - Menschen, die sich ehrenamtlich für die Gesellschaft von morgen einsetzen wollen.",
       "new-members": "We are always looking for new members!",
       "graphic-design": "Graphic Design",
       "software-development": "Software Development",
+      "business-finance": "Project Development",
       "pr-marketing": "PR & Marketing",
       "communication-marketing": "Communication & Marketing",
       "thao": "Content & Communication",
@@ -403,8 +403,8 @@
     "text3": "We want to set a good example and therefore develop the software transparently and openly. The source code of this project can be found under:",
     "heading4": "Workshops and events von morgen",
     "text4": "Together with our partner, the non-profit association Ideen³ e. V. and the \"Ideenwerkstatt Bildungsagenten\", we offer workshops on various topics to support the socio-ecological transformation.",
-    "clientVersion": "Version dieses Clients:",
-    "serverVersion": "Version des Servers:"
+    "clientVersion": "Version of this client:",
+    "serverVersion": "Version of the server:"
   },
   "category": {
     "initiative": "Initiative",
@@ -418,18 +418,17 @@
     "showMoreEntries": "Show more entries...",
     "entriesLoading": "Entries are loaded...",
     "noEntriesFound": "No entries found.",
-    "addEntry": "add a new entry"
+    "addEntry": "Add a new entry"
   },
   "growler": {
     "INFO FOR TRANSLATORS": "Growler is the green or red bar that appears at the top of the screen for example when saving an entry",
     "genericError": "Ops! An error has occurred...",
     "subscriptionChanged": "You subscription has been changed.",
     "subscriptionAdded": "You subscribed to a map section.",
-    "unsubscribingSuccessfull": "You unsubscribed from the map section",
+    "unsubscribingSuccessfull": "You unsubscribed from the map section.",
     "entrySaved": "Entry has been saved.",
     "ratingSaved": "Rating has been saved.",
-    "linkCopied": "Link copied to clipboard successfully!",
-    "iframeCopied": "Iframe copied to clipboard successfully!"
+    "linkCopied": "Link copied to clipboard successfully!"
   },
   "contact": {
     "heading": "Contact",
@@ -472,7 +471,7 @@
       "donate": "Donate"
     },
     "embed": {
-      "findOutMore": "Find out more about sharing options"
+      "findOutMore": "Find out more about map sharing and embedding options"
     }
   },
   "share": "Share",

--- a/src/locales/translation-es.json
+++ b/src/locales/translation-es.json
@@ -1,131 +1,131 @@
 {
   "entryForm": {
     "category": {
-      "initiative": "Iniciativa (Involucrarse, inspiración y cambio)",
+      "initiative": "Iniciativa (compromiso, inspiración y cambio)",
       "event": "Evento",
-      "company": "Empresa (Tiendas, servicios y necesidades)"
+      "company": "Empresa (tiendas, servicios y necesidades)"
     },
-    "chooseCategory": "Seleccione una categoría",
-    "location": "Sitio",
-    "clickMap": "(haga clic en el mapa)",
+    "chooseCategory": "Selecciona una categoría",
+    "location": "Lugar",
+    "clickMap": "(pulsa sobre el mapa)",
     "iHaveRead": "He leído los",
-    "creativeCommonsLicense": "términos de la Licencia Creative Commons CC0",
-    "openDatabaseLicense": "Términos de la licencia de OpenDatabase",
-    "licenseAccepted": "He leído las condiciones y las acepto",
+    "creativeCommonsLicense": "términos de la licencia Creative Commons CC0",
+    "openDatabaseLicense": "términos de la Licencia Abierta de Bases de Datos (ODbL)",
+    "licenseAccepted": "y los acepto.",
     "license": "Licencia",
     "title": "Título",
-    "start": "Inicio",
+    "start": "Comienzo",
     "end": "Final",
     "description": "Descripción",
-    "keepDescriptionShort": "¡Que sea breve! A los usuarios no les gusta leer tanto. Por defecto, se pueden ver un máximo de 250 caracteres.",
-    "tags": "Palabras clave",
-    "newTag": "Nuevo:",
-    "noTagSuggestion": "Escriba sus sugerencias.",
-    "tagsLoading": "Las sugerencias están cargadas....",
+    "keepDescriptionShort": "¡Sé breve! A los usuarios no les gusta leer tanto. En un principio solo serán visibles un máximo de 250 caracteres.",
+    "tags": "Etiquetas",
+    "newTag": "Nueva:",
+    "noTagSuggestion": "Escribe tus sugerencias.",
+    "tagsLoading": "Cargando sugerencias...",
     "contactPerson": "Persona de contacto",
-    "homepage": "página de inicio",
+    "homepage": "Sitio web",
     "phone": "Teléfono",
-    "street": "Calle y número de la casa",
+    "street": "Dirección (calle, número, etc)",
     "city": "Ciudad",
     "zip": "Código postal",
     "email": "Correo electrónico",
     "openingHours": "Horario de apertura",
-    "clickOnMap": "o haga clic en el mapa....",
+    "clickOnMap": "o pulsa sobre el mapa...",
     "contact": "Contacto (opcional)",
     "entryImage": "Imagen de portada (opcional)",
     "imageUrlExplanation": "Recomendado: formato apaisado, mín. 400x300 píxeles, máx. 300KB",
     "imageUrl": "URL de la imagen",
-    "imageLink": "Enlace (si hace clic en la imagen, opcional)",
-    "cancel": "romperse",
-    "save": "acumular",
+    "imageLink": "Enlace (al pulsar sobre la imagen, opcional)",
+    "cancel": "cancelar",
+    "save": "guardar",
     "editEntryHeading": "Editar entrada",
     "newEntryHeading": "Entrada nueva",
-    "savingError": "No se ha podido grabar la entrada.",
-    "valueError": "Por favor, compruebe sus entradas.",
-    "requiredField": "revelación obligatoria",
+    "savingError": "No se ha podido grabar la entrada",
+    "valueError": "Por favor, comprueba el contenido.",
+    "requiredField": "información requerida",
     "titleTooLong": "Título demasiado largo",
     "titleTooShort": "Título demasiado corto",
-    "maxNumCharactersTitle": "máx. 50 caracteres",
-    "minNumCharactersTitle": "min. 3 caracteres",
+    "maxNumCharactersTitle": "de máx. 50 caracteres",
+    "minNumCharactersTitle": "de mín. 3 caracteres",
     "invalidValues": "Datos no válidos",
     "descriptionTooLong": "Descripción demasiado larga",
     "descriptionTooShort": "Demasiado poco texto",
-    "maxNumCharactersDescription": "máx. 250 caracteres",
-    "minNumCharactersDescription": "min. 10 caracteres",
+    "maxNumCharactersDescription": "de máx. 250 caracteres",
+    "minNumCharactersDescription": "de mín. 10 caracteres",
     "invalidLatitude": "Latitud inválida",
     "invalidLongitude": "Longitud inválida",
     "invalidCategory": "Categoría no válida",
-    "invalidTags": "Palabras clave no válidas",
-    "minNumCharactersTags": "Longitud mínima de las palabras clave: 3 caracteres",
+    "invalidTags": "Etiquetas no válidas",
+    "minNumCharactersTags": "Longitud mínima de las etiquetas: 3 caracteres",
     "acceptLicense": "Se requiere la aprobación de la licencia",
     "invalidLicenseAgreement": "Consentimiento no válido",
     "invalidURL": "URL no válida",
-    "httpMissing": "\"http://\" o \"https://\" falta)",
-    "generateHours": "Generar horario de apertura!"
+    "httpMissing": "falta \"http://\" o \"https://\")",
+    "generateHours": "¡Configura el horario de apertura!"
   },
   "entryDetails": {
-    "loadingEntry": "La entrada está cargada...",
-    "back": "reverso",
+    "loadingEntry": "Cargando entrada...",
+    "back": "volver",
     "homepagePlaceholder": "Página de inicio",
     "viewHistory": "Ver el historial o archivar esta entrada",
-    "viewHistoryTooltip": "Tendrás que volver a entrar en openfairdb.org",
+    "viewHistoryTooltip": "Deberás reiniciar sesión en openfairdb.org",
     "reportLink": "Informar de esta entrada",
-    "reportSubject": "Informar de esta entrada",
-    "reportBody": "Con la entrada {enlace} hay el siguiente problema:",
+    "reportSubject": "Informar de la entrada",
+    "reportBody": "Hay este problema con la entrada {enlace}:",
     "readMore": "Leer más...",
     "lastEdit": "Último cambio:",
     "today": "hoy",
     "daysAgo": "días",
     "eventRegistrationInfo": {
       "email": "Registro por correo electrónico",
-      "telephone": "Inscripción por teléfono",
-      "homepage": "Inscripción en línea"
+      "telephone": "Registro por teléfono",
+      "homepage": "Registro en línea"
     },
     "route": "Ruta"
   },
   "login": {
-    "requiredField": "revelación obligatoria",
-    "loginFailed": "El inicio de sesión falló",
+    "requiredField": "información requerida",
+    "loginFailed": "Falló el inicio de sesión",
     "invalidValues": "Datos no válidos",
-    "invalidEmail": "Dirección de correo electrónico no válida",
+    "invalidEmail": "Dirección de correo electrónico inválida",
     "invalidPassword": "Contraseña inválida",
-    "invalidPasswordOrEmail": "Contraseña o nombre de usuario incorrectos.",
-    "emailUnconfirmed": "Dirección de correo electrónico aún no confirmada. Por favor, mire en su buzón de correo, posiblemente también en su carpeta de spam..",
-    "minNumCharactersPassword": " min. 3 caracteres",
+    "invalidPasswordOrEmail": "Contraseña o nombre de usuario/a incorrectos.",
+    "emailUnconfirmed": "Dirección de correo electrónico aún no confirmada. Por favor, comprueba tu buzón de correo, sin olvidar tu carpeta de spam.",
+    "minNumCharactersPassword": "de mín. 3 caracteres",
     "email": "Correo electrónico",
     "password": "Contraseña",
-    "loginButton": "de acceso",
+    "loginButton": "Inicio de sesión",
     "registerText": "¿Aún no tienes una cuenta? Entonces puedes",
-    "registerLink": "regístrese aquí gratis.",
+    "registerLink": "registrarte aquí gratis.",
     "passwordResetText": "¿Olvidaste tu contraseña?",
     "passwordResetLink": "Restablecer"
   },
   "register": {
-    "heading": "matricular",
-    "genericError": "El registro falló. El nombre de usuario o la dirección de correo electrónico ya están registrados.",
+    "heading": "Registro",
+    "genericError": "El registro falló. La dirección de correo electrónico ya está registrada.",
     "email": "Correo electrónico",
     "password1": "Contraseña",
     "password2": "Repetir contraseña",
-    "submitButton": "matricular",
-    "loginText": "¿Ya tienes una cuenta? Entonces puedes",
-    "loginLink": "ingrese aquí",
-    "requiredField": "revelación obligatoria",
+    "submitButton": "Registrar",
+    "loginText": "¿Ya tienes una cuenta? Entonces aquí puedes",
+    "loginLink": "iniciar sesión",
+    "requiredField": "información requerida",
     "invalidValues": "Datos no válidos",
-    "invalidEmail": "Dirección de correo electrónico no válida",
+    "invalidEmail": "Dirección de correo electrónico inválida",
     "invalidPassword": "Contraseña inválida",
-    "minNumCharactersPassword": "min. 3 caracteres",
-    "repeatPassword": "Por favor, introduzca la contraseña aquí de nuevo para verificarlo.",
+    "minNumCharactersPassword": "de mín. 3 caracteres",
+    "repeatPassword": "Por favor, por verificación repite aquí la contraseña.",
     "passwordsDontAgree": "Las contraseñas no coinciden"
   },
   "ratings": {
-    "requiredField": "revelación obligatoria",
+    "requiredField": "información requerida",
     "rating": "valoración",
-    "rating-heading": "valoración",
-    "ratings": "valoración",
-    "heading": "valoración",
-    "noRatingsYet": "Todavía no se han publicado reseñas para esta entrada.",
-    "giveFirstRating": "tasa ahora",
-    "newRating": "Enviar calificación",
+    "rating-heading": "Valoración",
+    "ratings": "valoraciones",
+    "heading": "Valoraciones",
+    "noRatingsYet": "Todavía no hay valoraciones para esta entrada.",
+    "giveFirstRating": "valora tú ahora",
+    "newRating": "Enviar valoración",
     "newComment": "Comentar",
     "sourceWebsite": "fuente",
     "contextName": {
@@ -137,50 +137,50 @@
       "solidarity": "solidaridad"
     },
     "contextExplanation": {
-      "diversity": "Diversidad ecológica, orgánica, pocos aditivos, etc.",
+      "diversity": "Diversidad ecológica, bienestar animal, certificaciones orgánicas, aditivos escasos, etc.",
       "renewable": "Protección del medio ambiente, rutas de transporte cortas, uso eficiente/bajo de materias primas y energía, economía circular, etc.",
-      "fairness": "Condiciones de trabajo seguras, inclusivas, justas y adecuadas en toda la cadena de valor.",
-      "humanity": "¿Todos los participantes tienen espacio para sus propias ideas, desarrollo y diversidad cultural? ¿Existen derechos de cogestión y procesos democráticos?",
-      "transparency": "¿Son las cadenas de producción, financiamiento y venta al por menor públicamente trazables? ",
-      "solidarity": "Métodos de trabajo cooperativo, financiación e inversiones sostenibles y éticas, accesibles para todos los presupuestos, …"
+      "fairness": "Condiciones de trabajo seguras, inclusivas, justas y adecuadas en toda la cadena de creación de valor.",
+      "humanity": "¿Todos/as los/las participantes tienen espacio para sus propias ideas, su desarrollo y diversidad cultural? ¿Existen derechos de cogestión y procesos democráticos?",
+      "transparency": "¿Se pueden trazar públicamente las cadenas de producción, financiación y comercio? ",
+      "solidarity": "Métodos cooperativos de trabajo, financiamiento e inversiones sostenibles y éticas, accesibles para todos los presupuestos, etc."
     },
     "valueName": {
-      "minusOne": "de ayer",
-      "zero": "de hoy",
-      "one": "de mañana",
-      "two": "de amplias miras"
+      "minusOne": "anticuado",
+      "zero": "corriente",
+      "one": "del mañana",
+      "two": "visionario"
     },
     "valueNameExplanation": {
-      "minusOne": "alguna crítica",
+      "minusOne": "variados aspectos criticables",
       "zero": "no particularmente sostenible",
-      "one": "innovadora",
-      "two": "¡No se me ocurre una forma mejor!!"
+      "one": "mostrando el futuro",
+      "two": "¡mejor imposible!"
     }
   },
   "ratingForm": {
     "newRatingFor": "Nueva valoración para",
-    "introText": "Los factores positivos determinan la visibilidad de una entrada en el mapa de mañana. Cuanto mayor sea la proporción de aspectos positivos de una organización, mayor será el pin en los resultados de búsqueda.",
+    "introText": "Los factores positivos determinan la visibilidad de una entrada en el mapa del mañana. Cuanto mayor sea la proporción de aspectos positivos de una organización, más subirá el pin en los resultados de búsqueda.",
     "moreInfoLink": "más información",
-    "savingError": "La clasificación no se ha podido guardar",
-    "valuesError": "Por favor, compruebe sus datos.",
-    "chooseContext": "Elija un aspecto de la sostenibilidad para su evaluación",
-    "title": "epígrafe",
+    "savingError": "La valoración no se ha podido guardar",
+    "valuesError": "Por favor, comprueba tus datos.",
+    "chooseContext": "Elije un aspecto de la sostenibilidad a evaluar",
+    "title": "Título",
     "comment": "Comentario/Explicación",
-    "reference": "Fuente (por ejemplo, un enlace o \"Estoy trabajando allí\", etc.)",
-    "ratingHeading": "evaluación",
-    "cancel": "romperse",
-    "save": "valorar",
-    "requiredField": "revelación obligatoria",
+    "reference": "Fuente (por ejemplo un enlace, o \"trabajo allá\", etc.)",
+    "ratingHeading": "Valoración",
+    "cancel": "cancelar",
+    "save": "guardar",
+    "requiredField": "información requerida",
     "titleTooLong": "Título demasiado largo",
     "titleTooShort": "Título demasiado corto",
-    "maxNumCharactersTitle": "máx. 40 caracteres",
-    "minNumCharactersTitle": "min. 3 caracteres",
-    "invalidRatingContext": "Contexto de valoración no válido",
-    "invalidRating": "Valoración no válida",
-    "commentTooLong": "comentario demasiado largo",
+    "maxNumCharactersTitle": "de máx. 40 caracteres",
+    "minNumCharactersTitle": "de mín. 3 caracteres",
+    "invalidRatingContext": "Contexto para la valoración no válido",
+    "invalidRating": "Valoración inválida",
+    "commentTooLong": "Comentario demasiado largo",
     "commentTooShort": "Demasiado poco texto",
-    "maxNumCharactersComment": " máx. 500 caracteres",
-    "minNumCharactersComment": "von Mínimo 10 caracteres"
+    "maxNumCharactersComment": "de máx. 500 caracteres",
+    "minNumCharactersComment": "de mín. 10 caracteres"
   },
   "commentForm": {
     "chooseContext": "Añade tu valoración al siguiente aspecto de la sostenibilidad de esta entrada",
@@ -189,124 +189,124 @@
   },
   "subscribeToBbox": {
     "changeSubscription": {
-      "heading": "Su suscripción",
-      "text1": "Se ha suscrito a un sector cartográfico y se le notificarán por correo electrónico las nuevas entradas y los cambios en este sector.",
-      "text2": "Si desea cambiar el sector cartográfico suscrito, navegue hasta el sector cartográfico que le interese y haga clic en \"cambiar \"."
+      "heading": "Tu suscripción",
+      "text1": "Te has suscrito a una sección del mapa y se te notificarán por correo electrónico las nuevas entradas y los cambios en esta sección.",
+      "text2": "Si deseas cambiar la sección del mapa suscrita, navega hasta la sección que te interese y pulsa sobre \"cambiar \"."
     },
     "newSubscription": {
-      "heading": "Suscribirse a la sección de mapas",
-      "text1": "Navegue hasta la sección del mapa que le interesa y haga clic en \"suscribirse\". A continuación, se le informará por correo electrónico sobre las nuevas entradas y los cambios en las entradas de esta región.",
-      "text2": "Usted puede darse de baja o cambiar su suscripción aquí en cualquier momento."
+      "heading": "Suscribirse a la sección del mapa",
+      "text1": "Navega hasta la sección del mapa que te interese y pulsa sobre \"suscribir\". Entonces se te informará por correo electrónico sobre las nuevas entradas y los cambios en las entradas de esta región.",
+      "text2": "Aquí puedes anular o cambiar tu suscripción en cualquier momento."
     },
-    "cancel": "romerse",
-    "edit": "modificar",
-    "unsubscribe": "anular la suscripción",
-    "back": "romperse",
-    "subscribe": "suscribirse"
+    "cancel": "cancelar",
+    "edit": "cambiar",
+    "unsubscribe": "anular suscripción",
+    "back": "volver",
+    "subscribe": "suscribir"
   },
   "search-results": {
     "cities": "ciudades",
-    "results-out-of-bbox": "Otros resultados fuera del área visible del mapa:"
+    "results-out-of-bbox": "Más resultados fuera del área visible del mapa:"
   },
-  "loading-message": "Cargar datos desde el servidor....",
+  "loading-message": "Cargando datos desde el servidor...",
   "io-error": {
-    "message": "Servidor no disponible. Por favor, compruebe su conexión a Internet o inténtelo de nuevo más tarde.",
+    "message": "Servidor no disponible. Por favor, comprueba tu conexión a Internet o inténtalo de nuevo más tarde.",
     "close": "cerrar"
   },
   "landingPage": {
     "menu": {
       "map": "Mapa",
       "infos": "Sobre nosotros",
-      "contact": "Contáctenos",
-      "donate": "Donaciones",
-      "login": "De acceso",
-      "logout": "Cierre de sesión"
+      "contact": "Contacto",
+      "donate": "Donar",
+      "login": "Iniciar sesión",
+      "logout": "Cerrar sesión"
     },
-    "slogan": "Descubra el buen vivir",
+    "slogan": "El mapa del buen vivir",
     "city-search": {
-      "placeholder": "¿Qué lugar le gustaría descubrir?",
-      "error": "Error en la búsqueda de la ciudad.",
-      "no-results": "No pude encontrar una ciudad con ese nombre.",
-      "show-map": "Mostrar mapa...."
+      "placeholder": "¿Qué lugar te gustaría descubrir?",
+      "error": "Error al buscar ciudades.",
+      "no-results": "No se pudo encontrar ninguna ciudad con ese nombre.",
+      "show-map": "Mostrar mapa..."
     },
     "subscribeToBbox": {
-      "message": "Ha iniciado sesión. Si quieres puedes",
-      "new-link": "manténgase al día sobre los cambios en su ciudad",
-      "edit-link": "cambiar o cancelar el sector cartográfico al que está suscrito"
+      "message": "Has iniciado sesión. Si lo deseas puedes",
+      "new-link": "mantenerte al día sobre los cambios en tu región",
+      "edit-link": "cambiar o anular tu subscripción a una sección del mapa"
     },
     "donate": {
-      "heading": "Haz algo bueno para mañana.",
-      "paragraph1": "El mapa del mañana debe estar siempre a disposición de nuestra comunidad de forma gratuita. Es por eso que lo estamos desarrollando como Open Source. El desarrollo técnico y el mantenimiento son posibles gracias a las donaciones solidarias de los usuarios* y de las iniciativas y empresas que se han cartografiado. Recomendamos una contribución mensual de 15 a 25 euros para las empresas y hasta 3 euros para las iniciativas y los usuarios* para garantizar el crecimiento orgánico y la independencia.",
-      "betterplace-link": "Done ahora para \"de mañana - descubra el buen vivir\" en nuestro socio betterplace.org",
+      "heading": "Haz algo bueno por el mañana.",
+      "paragraph1": "El mapa del mañana debe permanecer a disposición de nuestra comunidad siempre de forma gratuita. Para ello lo estamos desarrollando en Código Abierto. Su mantenimiento y desarrollo técnico continuado se hacen posibles a través de las donaciones solidarias de los/las usuarios/as de las iniciativas y empresas cartografiadas. Por eso recomendamos una contribución mensual de 15 a 25 euros mensuales para las empresas y hasta 3 euros para las iniciativas y los/las usuarios/as, para garantizar un crecimiento orgánico y permanecer independentes.",
+      "betterplace-link": "Dona ahora para \"del mañana - El mapa del buen vivir\" a través de nuestro socio betterplace.org",
       "paragraph2": {
-        "heading": "cuenta de donaciones:",
+        "heading": "Cuenta de donaciones:",
         "bank-details1": "Ideen hoch drei e.V. ",
         "bank-details2": "IBAN: DE05 4306 0967 4031 0759 00",
-        "bank-details3": "BIC: GENODEM1GLS en el Banco GLS",
-        "bank-details4": "Uso previsto: Mapa del mañana",
-        "text": "La plataforma de mañana también se financiará mediante subvenciones de diversos programas y concursos de ideas. Nosotros, el equipo del mañana, seguimos trabajando de forma honorífica, pero queremos profesionalizar el desarrollo y el apoyo a largo plazo y pagar salarios justos."
+        "bank-details3": "BIC: GENODEM1GLS en el banco GLS",
+        "bank-details4": "Concepto: Mapa del mañana",
+        "text": "La plataforma del mañana también se financia mediante subvenciones de diversos programas y concursos de ideas. Nosotros/as, el equipo del mañana, seguimos haciendo trabajo voluntario, pero queremos profesionalizar el desarrollo y el asesoramiento a largo plazo y tener salarios justos."
       },
       "paragraph3": {
         "heading": "Las regiones piloto del mañana",
-        "text1": "Nos vemos a nosotros mismos como una iniciativa visionaria y diversa que quiere hacer visible el cambio positivo en nuestra sociedad. Para garantizar esto de la mejor manera posible, estamos desarrollando las regiones piloto del mañana, que serán moderadas localmente por un*n piloto regional*. ¿Conoce muy bien su entorno y le gustaría formar parte de una región piloto del mañana? Entonces siéntase libre de contactarnos por correo o con esto",
+        "text1": "Nos vemos a nosotros/as mismos/as como una iniciativa visionaria y diversa de integración en red que desea hacer visible el cambio positivo en nuestra sociedad. Para conseguirlo de la mejor manera posible, actualmente estamos desarrollando las regiones piloto del mañana, que serán moderadas localmente por un/a piloto regional*. ¿Conoces muy bien tu entorno y te gustaría formar parte de una región piloto del mañana? Entonces siéntete libre de contactarnos por correo o a través de este",
         "form-link": "formulario",
-        "text2": ". Juntos haremos que el mundo del mañana sea visible hoy.",
-        "text3": "En nuestra página de donaciones de Betterplace encontrará un resumen actualizado de todas las funciones que se desarrollarán para el mapa del mañana:",
-        "text4": "Pero incluso los pequeños errores, optimizaciones y actualizaciones necesitan recursos.",
-        "text5": "Por lo tanto, estamos contentos con cada pequeña y gran contribución.",
-        "text6": "Muchísimas gracias.",
+        "text2": ". Juntos hacemos que el mundo del mañana ya sea visible hoy.",
+        "text3": "En nuestra página de donaciones de Betterplace encontrarás un resumen actualizado de todas las funciones a desarrollar en el mapa del mañana:",
+        "text4": "Pero incluso la corrección de pequeños errores, las optimizaciones y las actualizaciones necesitan recursos.",
+        "text5": "Por eso nos alegra cada pequeña o gran contribución.",
+        "text6": "¡Muchísimas gracias!",
         "text7": "el equipo del mañana"
       }
     },
     "user": {
       "register-success": {
-        "text1": "Se ha registrado correctamente. Por favor, confirme su dirección de correo electrónico, entonces usted puede ",
-        "text2": "te conectas. Para ello acabamos de enviar un correo electrónico a ",
-        "text3": " enviado"
+        "text1": "Te has registrado correctamente. Por favor, confirma tu dirección de correo electrónico, entonces podrás ",
+        "text2": "iniciar sesión. Para ello acabamos de enviar un mensaje a ",
+        "text3": "."
       },
       "confirming-email-address": {
-        "text": "Su dirección de correo electrónico está siendo confirmada."
+        "text": "Tu dirección de correo electrónico está siendo confirmada."
       },
       "confirm-email-error": {
-        "message": "Oops! Se ha producido un error al confirmar su dirección de correo electrónico. Por favor, inténtalo de nuevo con un nuevo nombre de usuario.",
-        "link": "registrarse"
+        "message": "¡Oh! Se ha producido un error al confirmar tu dirección de correo electrónico. Por favor, inténtalo de nuevo con un nuevo nombre de usuario/a al ",
+        "link": "registrarte."
       },
       "email-confirmed": {
-        "text1": "Su dirección de correo electrónico ha sido confirmada.",
-        "text2": "puedes entrar ahí ahora.",
-        "link": "registrarse"
+        "text1": "Tu dirección de correo electrónico ha sido confirmada.",
+        "text2": "Ahora puedes ",
+        "link": "iniciar sesión."
       },
-      "logged-out": "Estás desconectado."
+      "logged-out": "Se ha cerrado la sesión."
     },
     "join": {
-      "heading": " Forme parte de nuestro equipo",
-      "paragraph1": "Somos un equipo de toda Alemania y siempre estamos buscando nuevos miembros! Puede encontrar nuestros anuncios actuales aquí:",
-      "paragraph2": "Buscamos pilotos regionales y temáticos: como contacto local, usted se asegurará de la calidad de las entradas del mapa, organizará actividades y talleres y mostrará su ciudad desde su mejor lado!",
-      "paragraph3": "¿Tiene alguna pregunta o interés? Esperamos tener noticias suyas:"
+      "heading": "Forma parte de nuestro equipo",
+      "paragraph1": "Somos un equipo repartido por Alemania ¡y siempre estamos buscando nuevos miembros! Aquí encontrarás nuestras convocatorias actuales:",
+      "paragraph2": "Buscamos pilotos regionales y temáticos: como contacto local directo aseguras la calidad de las entradas del mapa, organizas actividades y talleres ¡y muestras lo mejor de tu ciudad!",
+      "paragraph3": "¿Tienes preguntas o estás interesado/a? Nos alegrará saber de ti:"
     },
     "footer": {
-      "heading": "Mostramos a la gente que quiere hacer el bien, donde hay bien.",
+      "heading": "Mostramos dónde hay bien a la gente que quiere hacer el bien.",
       "contact": "Contacto: ",
-      "social-media": "Medios de comunicación social: ",
+      "social-media": "Redes sociales: ",
       "open-source": "Código Abierto: ",
       "imprint": "Aviso Legal",
-      "privacyStatement": "Declaración de Privacidad"
+      "privacyStatement": "Declaración de privacidad"
     }
   },
   "landingExplain": {
     "chapter1": {
-      "heading": "El mundo está lleno de exploradores. Y lleno de lugares que esperan ser descubiertos.",
+      "heading": "El mundo está lleno de exploradores/as. Y lleno de lugares que esperan ser descubiertos.",
       "paragraph1": {
-        "heading": "Descubra los lugares de su mejor lado.",
-        "text": "Nuestro mapa le muestra las iniciativas orientadas al futuro, las empresas y pronto también los eventos directamente en su área."
+        "heading": "Descubre lo mejor de cada sitio.",
+        "text": "Nuestro mapa te muestra iniciativas y empresas orientadas hacia el futuro y pronto también eventos directamente en tu zona."
       },
       "paragraph2": {
-        "heading": "Únete a nosotros!",
-        "text": "¿Está particularmente interesado en una iniciativa? Con nosotros encontrará toda la información que necesita para ponerse en contacto y visitarnos."
+        "heading": "¡Participa!",
+        "text": "¿Estás particularmente interesado/a en una iniciativa? Con nosotros/as encontrarás toda la información que necesitas para tomar contacto y pasarte por ahí."
       },
       "paragraph3": {
         "heading": "Crea el mundo del mañana.",
-        "text": "Junto con usted queremos hacer visible y vivible el cambio positivo de nuestra sociedad."
+        "text": "Junto contigo queremos hacer visible y vivible el cambio positivo de nuestra sociedad."
       }
     },
     "chapter2": {
@@ -315,8 +315,8 @@
     "chapter3": {
       "heading": "La visión del mañana",
       "text": {
-        "1": "de mañana promueve la creatividad, el respeto al medio ambiente y la acción conjunta en el colorido campo del cambio social.",
-        "2": "de mañana tiene la visión de un mundo intacto, en el que las personas viven juntas una vida autodeterminada, feliz y consciente del medio ambiente. El objetivo: un futuro humano."
+        "1": "del mañana promueve la creatividad, el respeto al medio ambiente y la acción conjunta en el colorido campo del cambio social.",
+        "2": "del mañana tiene la visión de un mundo intacto, en el que las personas viven juntas una vida autodeterminada, feliz y amigable con el medio ambiente. El objetivo: un futuro humano."
       }
     },
     "chapter4": {
@@ -330,148 +330,148 @@
     },
     "chapter5": {
       "heading": "El equipo del mañana",
-      "new-members": "Estamos deseando que lleguen nuevos miembros al equipo!",
-      "graphic-design": "Diseño Gráfico",
-      "software-development": "Desarrollo de programas",
-      "business-finance": "Elaboración del proyecto",
+      "new-members": "¡Estamos deseando que lleguen nuevos/as miembros al equipo!",
+      "graphic-design": "Diseño gráfico",
+      "software-development": "Desarrollo de software",
+      "business-finance": "Elaboración de proyectos",
       "pr-marketing": "Relaciones Públicas y Marketing",
       "communication-marketing": "Comunicación y Marketing",
       "thao": "Contenidos y Comunicación",
-      "project-development": "Elaboración del proyecto",
-      "chair": "Junta directiva Ideen³ e.V.",
-      "lisa1": "Cientista político",
-      "lisa2": "Estrategia y Efecto",
-      "marten": "Atención plena y psicología del cambio",
+      "project-development": "Elaboración de proyectos",
+      "chair": "Junta Directiva de la asociación Ideen³ e.V.",
+      "lisa1": "Científica política",
+      "lisa2": "Estrategia e Impacto",
+      "marten": "Cuidados y psicología del cambio",
       "florian": "Consultoría de Desarrollo de Software",
       "louisa": "Trabajo Social",
-      "anja": "Diseñador",
-      "xueqian": "Consultor de gestión",
+      "anja": "Diseñadora",
+      "xueqian": "Consultora de gestión",
       "linus": "Sociología Global"
     },
     "chapter6": {
       "heading": "Un proyecto de"
     },
     "chapter7": {
-      "heading": "Nuestros Socios",
-      "boell-foundation": "El proyecto fue apoyado en la fase piloto por la Fundación Heinrich Böll."
+      "heading": "Nuestros socios",
+      "boell-foundation": "El proyecto fue patrocinado en la fase piloto por la Fundación Heinrich Böll."
     }
   },
   "donate": {
-    "heading": "Haz algo bueno para mañana.",
+    "heading": "Hacer algo bueno por el mañana.",
     "text": {
-      "1": "La plataforma de mañana será financiada a través de subvenciones de diversos programas y concursos, así como de donaciones. Nosotros, el equipo de mañana, somos voluntarios.",
-      "2": "Nos gustaría utilizar las donaciones para el desarrollo de la plataforma. Se han planificado varias características.",
-      "3": "Haga clic aquí para ver nuestra campaña de crowdfunding: ",
-      "4": "Estamos contentos por cada pequeña y gran contribución y esperamos estar disponibles en su ciudad pronto."
+      "1": "La plataforma del mañana se financia a través de subvenciones de diversos programas y concursos, así como de donaciones. Nosotros/as, el equipo del mañana, somos voluntarios/as.",
+      "2": "Nos gustaría utilizar las donaciones para el desarrollo de la plataforma. Hay diversas funcionalidades planificadas.",
+      "3": "Por aquí puedes ver nuestra campaña de crowdfunding: ",
+      "4": "Nos alegramos por cada pequeña o gran contribución y esperamos estar pronto disponibles también en tu ciudad."
     },
-    "ending": "Gracias, el equipo de mañana"
+    "ending": "Gracias, el equipo del mañana"
   },
   "join": {
     "heading": {
       "1": "Forme parte de nuestro equipo",
-      "2": "Conviértase en un piloto regional o temático"
+      "2": "Conviértete en piloto regional o temático"
     },
     "text": {
-      "1": "Somos un equipo de toda Alemania y siempre estamos buscando nuevos miembros! Puede encontrar nuestros anuncios actuales aquí:",
-      "2": "Buscamos pilotos regionales y temáticos: como persona de contacto directo in situ, usted se asegurará de la calidad de las entradas en los mapas, organizará eventos y talleres y mostrará su ciudad de la mejor manera posible.",
-      "3": "¿Tiene alguna pregunta o interés? Esperamos tener noticias suyas:"
+      "1": "Somos un equipo repartido por Alemania ¡y siempre estamos buscando nuevos miembros! Aquí encontrarás nuestras convocatorias actuales:",
+      "2": "Buscamos pilotos regionales y temáticos: como contacto local directo, aseguras la calidad de las entradas del mapa, organizas actividades y talleres ¡y muestras lo mejor de tu ciudad!",
+      "3": "¿Tienes preguntas o estás interesado/a? Nos alegrará saber de ti:"
     }
   },
   "info": {
-    "heading1": "El Proyecto",
-    "facebook": "Noticias y actualizaciones sobre",
-    "betterplace": "Informes sobre la marcha de los trabajos",
+    "heading1": "El proyecto",
+    "facebook": "Noticias y actualizaciones en",
+    "betterplace": "Informes sobre los progresos actuales en",
     "betterplace-link": "nuestro blog en Betterplace",
     "text1": {
-      "1": "Nuestro mapa interactivo le muestra los lugares de su entorno en los que ya puede trabajar hoy para un mundo de mañana.",
-      "2": "¿Tienes una iniciativa para la que buscas compañeros de armas?",
-      "3": "¿Conoce una empresa que opere de manera sostenible?",
-      "4": "En nuestra página web puede llamar la atención de los demás - y así defender un lugar diseñado por personas que están personalmente cerca de su corazón..",
-      "5": "Buscamos ideas, iniciativas y empresas diversas que puedan contrarrestar los actuales trastornos sociales, ecológicos y económicos. Nos gustaría conectarlos en red y darles una presencia conjunta en línea y así aumentar su conciencia.",
-      "6": "Según el principio Wiki, todos los usuarios, iniciativas y empresas pueden registrarse a sí mismos y a otros en el mapa y así llegar a sus semejantes. Pero mañana habrá algo más que una plataforma en línea: los pilotos regionales garantizarán la calidad de las entradas del mapa en el sitio y, además de una función editorial, tendrán la tarea de reforzar el intercambio regional entre ciudadanos*, iniciativas y empresas a través de eventos y campañas educativas",
-      "7": "de mañana se pregunta sobre los valores en los que se basa nuestra sociedad y que la mueven. Mostramos a la gente que hace el bien, donde hay bien."
+      "1": "Nuestro mapa interactivo te muestra lugares de tu entorno en los que ya hoy se trabaja por un mundo del mañana.",
+      "2": "¿Tienes una iniciativa para la que buscas colaboradores/as?",
+      "3": "¿Conoces una empresa que opera de manera sostenible?",
+      "4": "En nuestro sitio web puedes llamar la atención de los demás, y así implicarte por un lugar al que aprecias que está configurado por personas.",
+      "5": "Buscamos ideas, iniciativas y empresas diversas que puedan contrarrestar las actuales convulsiones sociales, ecológicas y económicas. Nos gustaría conectarlas en red y darles una presencia conjunta en línea para hacer posible una mayor visibilidad.",
+      "6": "Según el principio wiki, todos los/las usuarios/as, iniciativas y empresas pueden registrarse a sí mismas y a otros/as en el mapa y así llegar a sus semejantes. Pero del mañana es más que una plataforma en línea: los/las pilotos regionales garantizan la calidad de las entradas en el mapa y, además de una función editorial, tienen la tarea de reforzar el intercambio regional entre ciudadanos/as, iniciativas y empresas a través de eventos y campañas educativas",
+      "7": "del mañana pregunta por los valores en los que se basa nuestra sociedad y que la mueven. Mostramos dónde hay bien a la gente que hace el bien."
     },
-    "heading2": "Antecedentes y visiones",
+    "heading2": "Trasfondo y visión",
     "text2": {
-      "goalLink": "¿Qué quiere el mapa de mañana?",
+      "goalLink": "¿Qué quiere el mapa del mañana?",
       "ratingsLink": "¿Cuáles son los factores positivos?",
       "regionalpilotLink": "¿Qué son los proyectos piloto regionales o temáticos?",
-      "embedMapLink": "¿Cómo puedo insertar el mapa en mi página de inicio?",
-      "joinLink": "¿Cómo puedo unirme o apoyar el mapa del mañana?"
+      "embedMapLink": "¿Cómo puedo integrar el mapa en mi sitio web?",
+      "joinLink": "¿Cómo puedo participar o apoyar al mapa del mañana?"
     },
-    "heading3": "Nos encanta el Código Abierto!",
-    "text3": "Queremos dar un buen ejemplo y, por lo tanto, desarrollar el software de forma transparente y abierta. El código fuente del proyecto conjunto se encuentra en :",
-    "heading4": "Talleres y actividades de mañana",
-    "text4": "Junto con nuestro socio, la asociación sin ánimo de lucro Ideen³ e.V. y el \"Ideenwerkstatt Bildungsagenten\", ofrecemos talleres sobre diversos temas para apoyar la transformación socio-ecológica.",
+    "heading3": "¡Nos encanta el Código Abierto!",
+    "text3": "Queremos dar buen ejemplo y, por lo tanto, desarrollamos el software de forma transparente y abierta. El código fuente de este proyecto comunitario se encuentra en:",
+    "heading4": "Talleres y actividades del mañana",
+    "text4": "Junto con nuestro socio, la asociación de utilidad pública Ideen³ e.V., y el \"Ideenwerkstatt Bildungsagenten\" (Taller de ideas Agentes educativos), ofrecemos talleres sobre diversos temas para apoyar la transformación socioecológica.",
     "clientVersion": "Versión de este cliente:",
     "serverVersion": "Versión del servidor:"
   },
   "category": {
     "initiative": "Iniciativa",
     "event": "Evento",
-    "company": "empresa"
+    "company": "Empresa"
   },
   "searchbar": {
-    "placeholder": "¿Qué es lo que buscas?"
+    "placeholder": "¿Qué es lo que buscas? (# para etiquetas)"
   },
   "resultlist": {
-    "showMoreEntries": "mostrar más entradas....",
-    "entriesLoading": "Se cargan las entradas....",
+    "showMoreEntries": "Mostrar más entradas...",
+    "entriesLoading": "Cargando las entradas...",
     "noEntriesFound": "No se han encontrado entradas.",
-    "addEntry": "Añadir entrada"
+    "addEntry": "Añadir nueva entrada"
   },
   "growler": {
     "INFO FOR TRANSLATORS": "Growler is the green or red bar that appears at the top of the screen for example when saving an entry",
-    "genericError": "Oops! Se ha producido un error....",
-    "subscriptionChanged": "La suscripción ha sido modificada.",
-    "subscriptionAdded": "Se ha suscrito la sección de mapas.",
-    "unsubscribingSuccessfull": "Se canceló la suscripción",
-    "entrySaved": "Se ha grabado la entrada.",
-    "ratingSaved": "La evaluación fue guardada.",
-    "linkCopied": "El enlace se ha copiado en el portapapeles"
+    "genericError": "¡Oh! Se ha producido un error...",
+    "subscriptionChanged": "Se ha modificado la suscripción.",
+    "subscriptionAdded": "Te has suscrito a la sección cartográfica.",
+    "unsubscribingSuccessfull": "Se ha cancelado la suscripción.",
+    "entrySaved": "Se ha guardado la entrada.",
+    "ratingSaved": "Se ha guardado la valoración.",
+    "linkCopied": "¡El enlace se ha copiado en el portapapeles!"
   },
   "contact": {
     "heading": "Contacto",
     "text1": "El equipo del mañana, representado por",
-    "showOnKVM": "Lugar en el mapa"
+    "showOnKVM": "Lugar en el mapa del mañana"
   },
   "imprint": {
     "contact": "Contacto",
-    "imprint": "Impressum",
-    "heading1": "Entidad jurídica en el sentido de la condición de entidad publica",
-    "representedByChair": "Representada por el Consejo de Administración",
+    "imprint": "Aviso legal",
+    "heading1": "Entidad jurídica portadora de la condición de utilidad pública",
+    "representedByChair": "Representada por la Junta Directiva",
     "kvmTeamRepresentedBy": "El equipo del mañana, representado por",
     "heading2": "Concepto",
-    "heading3": "Responsable del contenido según § 55 párrafo 2 RStV",
+    "heading3": "Responsable del contenido según la ley alemana RStV, art. 55 párrafo 2",
     "heading4": "Diseño",
     "heading5": "Ilustraciones",
     "heading6": "Implementación y programación"
   },
   "privacy": {
-    "title": "Declaración de Privacidad",
-    "text": "<p>We are very delighted that you have shown interest in our enterprise. Data protection is of a particularly high priority for the management of the Ideen³ e.V.. The use of the Internet pages of the Ideen³ e.V. is possible without any indication of personal data; however, if a data subject wants to use special enterprise services via our website, processing of personal data could become necessary. If the processing of personal data is necessary and there is no statutory basis for such processing, we generally obtain consent from the data subject.</p>\n\n<p>The processing of personal data, such as the name, address, e-mail address, or telephone number of a data subject shall always be in line with the General Data Protection Regulation (GDPR), and in accordance with the country-specific data protection regulations applicable to the Ideen³ e.V.. By means of this data protection declaration, our enterprise would like to inform the general public of the nature, scope, and purpose of the personal data we collect, use and process. Furthermore, data subjects are informed, by means of this data protection declaration, of the rights to which they are entitled.</p>\n\n<p>As the controller, the Ideen³ e.V. has implemented numerous technical and organizational measures to ensure the most complete protection of personal data processed through this website. However, Internet-based data transmissions may in principle have security gaps, so absolute protection may not be guaranteed. For this reason, every data subject is free to transfer personal data to us via alternative means, e.g. by telephone. </p>\n\n<h4>1. Definitions</h4>\n<p>The data protection declaration of the Ideen³ e.V. is based on the terms used by the European legislator for the adoption of the General Data Protection Regulation (GDPR). Our data protection declaration should be legible and understandable for the general public, as well as our customers and business partners. To ensure this, we would like to first explain the terminology used.</p>\n\n<p>In this data protection declaration, we use, inter alia, the following terms:</p>\n\n<ul style='list-style: none'>\n<li><h4>a)    Personal data</h4>\n<p>Personal data means any information relating to an identified or identifiable natural person (“data subject”). An identifiable natural person is one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person.</p>\n</li>\n<li><h4>b) Data subject</h4>\n<p>Data subject is any identified or identifiable natural person, whose personal data is processed by the controller responsible for the processing.</p>\n</li>\n<li><h4>c)    Processing</h4>\n<p>Processing is any operation or set of operations which is performed on personal data or on sets of personal data, whether or not by automated means, such as collection, recording, organisation, structuring, storage, adaptation or alteration, retrieval, consultation, use, disclosure by transmission, dissemination or otherwise making available, alignment or combination, restriction, erasure or destruction. </p>\n</li>\n<li><h4>d)    Restriction of processing</h4>\n<p>Restriction of processing is the marking of stored personal data with the aim of limiting their processing in the future. </p>\n</li>\n<li><h4>e)    Profiling</h4>\n<p>Profiling means any form of automated processing of personal data consisting of the use of personal data to evaluate certain personal aspects relating to a natural person, in particular to analyse or predict aspects concerning that natural person's performance at work, economic situation, health, personal preferences, interests, reliability, behaviour, location or movements. </p>\n</li>\n<li><h4>f)     Pseudonymisation</h4>\n<p>Pseudonymisation is the processing of personal data in such a manner that the personal data can no longer be attributed to a specific data subject without the use of additional information, provided that such additional information is kept separately and is subject to technical and organisational measures to ensure that the personal data are not attributed to an identified or identifiable natural person. </p>\n</li>\n<li><h4>g)    Controller or controller responsible for the processing</h4>\n<p>Controller or controller responsible for the processing is the natural or legal person, public authority, agency or other body which, alone or jointly with others, determines the purposes and means of the processing of personal data; where the purposes and means of such processing are determined by Union or Member State law, the controller or the specific criteria for its nomination may be provided for by Union or Member State law. </p>\n</li>\n<li><h4>h)    Processor</h4>\n<p>Processor is a natural or legal person, public authority, agency or other body which processes personal data on behalf of the controller. </p>\n</li>\n<li><h4>i)      Recipient</h4>\n<p>Recipient is a natural or legal person, public authority, agency or another body, to which the personal data are disclosed, whether a third party or not. However, public authorities which may receive personal data in the framework of a particular inquiry in accordance with Union or Member State law shall not be regarded as recipients; the processing of those data by those public authorities shall be in compliance with the applicable data protection rules according to the purposes of the processing. </p>\n</li>\n<li><h4>j)      Third party</h4>\n<p>Third party is a natural or legal person, public authority, agency or body other than the data subject, controller, processor and persons who, under the direct authority of the controller or processor, are authorised to process personal data.</p>\n</li>\n<li><h4>k)    Consent</h4>\n<p>Consent of the data subject is any freely given, specific, informed and unambiguous indication of the data subject's wishes by which he or she, by a statement or by a clear affirmative action, signifies agreement to the processing of personal data relating to him or her. </p>\n</li>\n</ul>\n\n<h4>2. Name and Address of the controller</h4>\n<p>Controller for the purposes of the General Data Protection Regulation (GDPR), other data protection laws applicable in Member states of the European Union and other provisions related to data protection is:\n\n</p>\n\n<p>Ideen³ e.V.</p>\n<p>Görreshof 180</p>\n<p>53347 Alfter</p>\n<p>Deutschland</p>\n<p>Phone: 01573-444 8245</p>\n<p>Email: info@ideenhochdrei.org</p>\n<p>Website: https://www.kartevonmorgen.org</p>\n\n<h4>3. Cookies</h4>\n<p>The Internet pages of the Ideen³ e.V. use cookies. Cookies are text files that are stored in a computer system via an Internet browser.</p>\n\n<p>Many Internet sites and servers use cookies. Many cookies contain a so-called cookie ID. A cookie ID is a unique identifier of the cookie. It consists of a character string through which Internet pages and servers can be assigned to the specific Internet browser in which the cookie was stored. This allows visited Internet sites and servers to differentiate the individual browser of the dats subject from other Internet browsers that contain other cookies. A specific Internet browser can be recognized and identified using the unique cookie ID.</p>\n\n<p>Through the use of cookies, the Ideen³ e.V. can provide the users of this website with more user-friendly services that would not be possible without the cookie setting.</p>\n\n<p>By means of a cookie, the information and offers on our website can be optimized with the user in mind. Cookies allow us, as previously mentioned, to recognize our website users. The purpose of this recognition is to make it easier for users to utilize our website. The website user that uses cookies, e.g. does not have to enter access data each time the website is accessed, because this is taken over by the website, and the cookie is thus stored on the user's computer system. Another example is the cookie of a shopping cart in an online shop. The online store remembers the articles that a customer has placed in the virtual shopping cart via a cookie.</p>\n\n<p>The data subject may, at any time, prevent the setting of cookies through our website by means of a corresponding setting of the Internet browser used, and may thus permanently deny the setting of cookies. Furthermore, already set cookies may be deleted at any time via an Internet browser or other software programs. This is possible in all popular Internet browsers. If the data subject deactivates the setting of cookies in the Internet browser used, not all functions of our website may be entirely usable.</p>\n\n<h4>4. Collection of general data and information</h4>\n<p>The website of the Ideen³ e.V. collects a series of general data and information when a data subject or automated system calls up the website. This general data and information are stored in the server log files. Collected may be (1) the browser types and versions used, (2) the operating system used by the accessing system, (3) the website from which an accessing system reaches our website (so-called referrers), (4) the sub-websites, (5) the date and time of access to the Internet site, (6) an Internet protocol address (IP address), (7) the Internet service provider of the accessing system, and (8) any other similar data and information that may be used in the event of attacks on our information technology systems.</p>\n\n<p>When using these general data and information, the Ideen³ e.V. does not draw any conclusions about the data subject. Rather, this information is needed to (1) deliver the content of our website correctly, (2) optimize the content of our website as well as its advertisement, (3) ensure the long-term viability of our information technology systems and website technology, and (4) provide law enforcement authorities with the information necessary for criminal prosecution in case of a cyber-attack. Therefore, the Ideen³ e.V. analyzes anonymously collected data and information statistically, with the aim of increasing the data protection and data security of our enterprise, and to ensure an optimal level of protection for the personal data we process. The anonymous data of the server log files are stored separately from all personal data provided by a data subject.</p>\n\n<h4>5. Registration on our website</h4>\n<p>The data subject has the possibility to register on the website of the controller with the indication of personal data. Which personal data are transmitted to the controller is determined by the respective input mask used for the registration. The personal data entered by the data subject are collected and stored exclusively for internal use by the controller, and for his own purposes. The controller may request transfer to one or more processors (e.g. a parcel service) that also uses personal data for an internal purpose which is attributable to the controller.</p>\n\n<p>By registering on the website of the controller, the IP address—assigned by the Internet service provider (ISP) and used by the data subject—date, and time of the registration are also stored. The storage of this data takes place against the background that this is the only way to prevent the misuse of our services, and, if necessary, to make it possible to investigate committed offenses. Insofar, the storage of this data is necessary to secure the controller. This data is not passed on to third parties unless there is a statutory obligation to pass on the data, or if the transfer serves the aim of criminal prosecution.\n\n</p>\n\n<p>The registration of the data subject, with the voluntary indication of personal data, is intended to enable the controller to offer the data subject contents or services that may only be offered to registered users due to the nature of the matter in question. Registered persons are free to change the personal data specified during the registration at any time, or to have them completely deleted from the data stock of the controller.</p>\n\n<p>The data controller shall, at any time, provide information upon request to each data subject as to what personal data are stored about the data subject. In addition, the data controller shall correct or erase personal data at the request or indication of the data subject, insofar as there are no statutory storage obligations. The entirety of the controller’s employees are available to the data subject in this respect as contact persons.</p>\n\n<h4>6. Subscription to our newsletters</h4>\n<p>On the website of the Ideen³ e.V., users are given the opportunity to subscribe to our enterprise's newsletter. The input mask used for this purpose determines what personal data are transmitted, as well as when the newsletter is ordered from the controller.</p>\n\n<p>The Ideen³ e.V. informs its customers and business partners regularly by means of a newsletter about enterprise offers. The enterprise's newsletter may only be received by the data subject if (1) the data subject has a valid e-mail address and (2) the data subject registers for the newsletter shipping. A confirmation e-mail will be sent to the e-mail address registered by a data subject for the first time for newsletter shipping, for legal reasons, in the double opt-in procedure. This confirmation e-mail is used to prove whether the owner of the e-mail address as the data subject is authorized to receive the newsletter.\n\n</p>\n\n<p>During the registration for the newsletter, we also store the IP address of the computer system assigned by the Internet service provider (ISP) and used by the data subject at the time of the registration, as well as the date and time of the registration. The collection of this data is necessary in order to understand the (possible) misuse of the e-mail address of a data subject at a later date, and it therefore serves the aim of the legal protection of the controller.</p>\n\n<p>The personal data collected as part of a registration for the newsletter will only be used to send our newsletter. In addition, subscribers to the newsletter may be informed by e-mail, as long as this is necessary for the operation of the newsletter service or a registration in question, as this could be the case in the event of modifications to the newsletter offer, or in the event of a change in technical circumstances. There will be no transfer of personal data collected by the newsletter service to third parties. The subscription to our newsletter may be terminated by the data subject at any time. The consent to the storage of personal data, which the data subject has given for shipping the newsletter, may be revoked at any time. For the purpose of revocation of consent, a corresponding link is found in each newsletter. It is also possible to unsubscribe from the newsletter at any time directly on the website of the controller, or to communicate this to the controller in a different way.</p>\n\n<h4>7. Newsletter-Tracking</h4>\n<p>The newsletter of the Ideen³ e.V. contains so-called tracking pixels. A tracking pixel is a miniature graphic embedded in such e-mails, which are sent in HTML format to enable log file recording and analysis. This allows a statistical analysis of the success or failure of online marketing campaigns. Based on the embedded tracking pixel, the Ideen³ e.V. may see if and when an e-mail was opened by a data subject, and which links in the e-mail were called up by data subjects.</p>\n\n<p>Such personal data collected in the tracking pixels contained in the newsletters are stored and analyzed by the controller in order to optimize the shipping of the newsletter, as well as to adapt the content of future newsletters even better to the interests of the data subject. These personal data will not be passed on to third parties. Data subjects are at any time entitled to revoke the respective separate declaration of consent issued by means of the double-opt-in procedure. After a revocation, these personal data will be deleted by the controller. The Ideen³ e.V. automatically regards a withdrawal from the receipt of the newsletter as a revocation.</p>\n\n<h4>8. Contact possibility via the website </h4>\n<p>The website of the Ideen³ e.V. contains information that enables a quick electronic contact to our enterprise, as well as direct communication with us, which also includes a general address of the so-called electronic mail (e-mail address). If a data subject contacts the controller by e-mail or via a contact form, the personal data transmitted by the data subject are automatically stored. Such personal data transmitted on a voluntary basis by a data subject to the data controller are stored for the purpose of processing or contacting the data subject. There is no transfer of this personal data to third parties.</p>\n\n<h4>9. Comments function in the blog on the website</h4>\n<p>The Ideen³ e.V. offers users the possibility to leave individual comments on individual blog contributions on a blog, which is on the website of the controller. A blog is a web-based, publicly-accessible portal, through which one or more people called bloggers or web-bloggers may post articles or write down thoughts in so-called blogposts. Blogposts may usually be commented by third parties.</p>\n\n<p>If a data subject leaves a comment on the blog published on this website, the comments made by the data subject are also stored and published, as well as information on the date of the commentary and on the user's (pseudonym) chosen by the data subject. In addition, the IP address assigned by the Internet service provider (ISP) to the data subject is also logged. This storage of the IP address takes place for security reasons, and in case the data subject violates the rights of third parties, or posts illegal content through a given comment. The storage of these personal data is, therefore, in the own interest of the data controller, so that he can exculpate in the event of an infringement. This collected personal data will not be passed to third parties, unless such a transfer is required by law or serves the aim of the defense of the data controller.</p>\n\n<h4>10. Subscription to comments in the blog on the website</h4>\n<p>\nThe comments made in the blog of the Ideen³ e.V. may be subscribed to by third parties. In particular, there is the possibility that a commenter subscribes to the comments following his comments on a particular blog post.\n</p>\n\n<p>If a data subject decides to subscribe to the option, the controller will send an automatic confirmation e-mail to check the double opt-in procedure as to whether the owner of the specified e-mail address decided in favor of this option. The option to subscribe to comments may be terminated at any time.</p>\n\n<h4>11. Routine erasure and blocking of personal data</h4>\n<p>The data controller shall process and store the personal data of the data subject only for the period necessary to achieve the purpose of storage, or as far as this is granted by the European legislator or other legislators in laws or regulations to which the controller is subject to.</p>\n\n<p>If the storage purpose is not applicable, or if a storage period prescribed by the European legislator or another competent legislator expires, the personal data are routinely blocked or erased in accordance with legal requirements.</p>\n\n<h4>12. Rights of the data subject</h4>\n<ul style='list-style: none;'>\n<li><h4>a) Right of confirmation</h4>\n<p>Each data subject shall have the right granted by the European legislator to obtain from the controller the confirmation as to whether or not personal data concerning him or her are being processed. If a data subject wishes to avail himself of this right of confirmation, he or she may, at any time, contact any employee of the controller.</p>\n</li>\n<li><h4>b) Right of access</h4>\n<p>Each data subject shall have the right granted by the European legislator to obtain from the controller free information about his or her personal data stored at any time and a copy of this information. Furthermore, the European directives and regulations grant the data subject access to the following information:</p>\n\n<ul style='list-style: none;'>\n<li>the purposes of the processing;</li>\n<li>the categories of personal data concerned;</li>\n<li>the recipients or categories of recipients to whom the personal data have been or will be disclosed, in particular recipients in third countries or international organisations;</li>\n<li>where possible, the envisaged period for which the personal data will be stored, or, if not possible, the criteria used to determine that period;</li>\n<li>the existence of the right to request from the controller rectification or erasure of personal data, or restriction of processing of personal data concerning the data subject, or to object to such processing;</li>\n<li>the existence of the right to lodge a complaint with a supervisory authority;</li>\n<li>where the personal data are not collected from the data subject, any available information as to their source;</li>\n<li>the existence of automated decision-making, including profiling, referred to in Article 22(1) and (4) of the GDPR and, at least in those cases, meaningful information about the logic involved, as well as the significance and envisaged consequences of such processing for the data subject.</li>\n\n</ul>\n<p>Furthermore, the data subject shall have a right to obtain information as to whether personal data are transferred to a third country or to an international organisation. Where this is the case, the data subject shall have the right to be informed of the appropriate safeguards relating to the transfer.</p>\n\n<p>If a data subject wishes to avail himself of this right of access, he or she may, at any time, contact any employee of the controller.</p>\n</li>\n<li><h4>c) Right to rectification </h4>\n<p>Each data subject shall have the right granted by the European legislator to obtain from the controller without undue delay the rectification of inaccurate personal data concerning him or her. Taking into account the purposes of the processing, the data subject shall have the right to have incomplete personal data completed, including by means of providing a supplementary statement.</p>\n\n<p>If a data subject wishes to exercise this right to rectification, he or she may, at any time, contact any employee of the controller.</p></li>\n<li>\n<h4>d) Right to erasure (Right to be forgotten) </h4>\n<p>Each data subject shall have the right granted by the European legislator to obtain from the controller the erasure of personal data concerning him or her without undue delay, and the controller shall have the obligation to erase personal data without undue delay where one of the following grounds applies, as long as the processing is not necessary: </p>\n\n<ul style='list-style: none;'>\n<li>The personal data are no longer necessary in relation to the purposes for which they were collected or otherwise processed.</li>\n<li>The data subject withdraws consent to which the processing is based according to point (a) of Article 6(1) of the GDPR, or point (a) of Article 9(2) of the GDPR, and where there is no other legal ground for the processing.</li>\n<li>The data subject objects to the processing pursuant to Article 21(1) of the GDPR and there are no overriding legitimate grounds for the processing, or the data subject objects to the processing pursuant to Article 21(2) of the GDPR. </li>\n<li>The personal data have been unlawfully processed.</li>\n<li>The personal data must be erased for compliance with a legal obligation in Union or Member State law to which the controller is subject.</li>\n<li>The personal data have been collected in relation to the offer of information society services referred to in Article 8(1) of the GDPR.</li>\n\n</ul>\n<p>If one of the aforementioned reasons applies, and a data subject wishes to request the erasure of personal data stored by the Ideen³ e.V., he or she may, at any time, contact any employee of the controller. An employee of Ideen³ e.V. shall promptly ensure that the erasure request is complied with immediately.</p>\n\n<p>Where the controller has made personal data public and is obliged pursuant to Article 17(1) to erase the personal data, the controller, taking account of available technology and the cost of implementation, shall take reasonable steps, including technical measures, to inform other controllers processing the personal data that the data subject has requested erasure by such controllers of any links to, or copy or replication of, those personal data, as far as processing is not required. An employees of the Ideen³ e.V. will arrange the necessary measures in individual cases.</p>\n</li>\n<li><h4>e) Right of restriction of processing</h4>\n<p>Each data subject shall have the right granted by the European legislator to obtain from the controller restriction of processing where one of the following applies:</p>\n\n<ul style='list-style: none;'>\n<li>The accuracy of the personal data is contested by the data subject, for a period enabling the controller to verify the accuracy of the personal data. </li>\n<li>The processing is unlawful and the data subject opposes the erasure of the personal data and requests instead the restriction of their use instead.</li>\n<li>The controller no longer needs the personal data for the purposes of the processing, but they are required by the data subject for the establishment, exercise or defence of legal claims.</li>\n<li>The data subject has objected to processing pursuant to Article 21(1) of the GDPR pending the verification whether the legitimate grounds of the controller override those of the data subject.</li>\n\n</ul>\n<p>If one of the aforementioned conditions is met, and a data subject wishes to request the restriction of the processing of personal data stored by the Ideen³ e.V., he or she may at any time contact any employee of the controller. The employee of the Ideen³ e.V. will arrange the restriction of the processing. </p>\n</li>\n<li><h4>f) Right to data portability</h4>\n<p>Each data subject shall have the right granted by the European legislator, to receive the personal data concerning him or her, which was provided to a controller, in a structured, commonly used and machine-readable format. He or she shall have the right to transmit those data to another controller without hindrance from the controller to which the personal data have been provided, as long as the processing is based on consent pursuant to point (a) of Article 6(1) of the GDPR or point (a) of Article 9(2) of the GDPR, or on a contract pursuant to point (b) of Article 6(1) of the GDPR, and the processing is carried out by automated means, as long as the processing is not necessary for the performance of a task carried out in the public interest or in the exercise of official authority vested in the controller.</p>\n\n<p>Furthermore, in exercising his or her right to data portability pursuant to Article 20(1) of the GDPR, the data subject shall have the right to have personal data transmitted directly from one controller to another, where technically feasible and when doing so does not adversely affect the rights and freedoms of others.</p>\n\n<p>In order to assert the right to data portability, the data subject may at any time contact any employee of the Ideen³ e.V..</p>\n\n</li>\n<li>\n<h4>g) Right to object</h4>\n<p>Each data subject shall have the right granted by the European legislator to object, on grounds relating to his or her particular situation, at any time, to processing of personal data concerning him or her, which is based on point (e) or (f) of Article 6(1) of the GDPR. This also applies to profiling based on these provisions.</p>\n\n<p>The Ideen³ e.V. shall no longer process the personal data in the event of the objection, unless we can demonstrate compelling legitimate grounds for the processing which override the interests, rights and freedoms of the data subject, or for the establishment, exercise or defence of legal claims.</p>\n\n<p>If the Ideen³ e.V. processes personal data for direct marketing purposes, the data subject shall have the right to object at any time to processing of personal data concerning him or her for such marketing. This applies to profiling to the extent that it is related to such direct marketing. If the data subject objects to the Ideen³ e.V. to the processing for direct marketing purposes, the Ideen³ e.V. will no longer process the personal data for these purposes.</p>\n\n<p>In addition, the data subject has the right, on grounds relating to his or her particular situation, to object to processing of personal data concerning him or her by the Ideen³ e.V. for scientific or historical research purposes, or for statistical purposes pursuant to Article 89(1) of the GDPR, unless the processing is necessary for the performance of a task carried out for reasons of public interest.</p>\n\n<p>In order to exercise the right to object, the data subject may contact any employee of the Ideen³ e.V.. In addition, the data subject is free in the context of the use of information society services, and notwithstanding Directive 2002/58/EC, to use his or her right to object by automated means using technical specifications.</p>\n</li>\n<li><h4>h) Automated individual decision-making, including profiling</h4>\n<p>Each data subject shall have the right granted by the European legislator not to be subject to a decision based solely on automated processing, including profiling, which produces legal effects concerning him or her, or similarly significantly affects him or her, as long as the decision (1) is not is necessary for entering into, or the performance of, a contract between the data subject and a data controller, or (2) is not authorised by Union or Member State law to which the controller is subject and which also lays down suitable measures to safeguard the data subject's rights and freedoms and legitimate interests, or (3) is not based on the data subject's explicit consent.</p>\n\n<p>If the decision (1) is necessary for entering into, or the performance of, a contract between the data subject and a data controller, or (2) it is based on the data subject's explicit consent, the Ideen³ e.V. shall implement suitable measures to safeguard the data subject's rights and freedoms and legitimate interests, at least the right to obtain human intervention on the part of the controller, to express his or her point of view and contest the decision.</p>\n\n<p>If the data subject wishes to exercise the rights concerning automated individual decision-making, he or she may, at any time, contact any employee of the Ideen³ e.V..</p>\n\n</li>\n<li><h4>i) Right to withdraw data protection consent </h4>\n<p>Each data subject shall have the right granted by the European legislator to withdraw his or her consent to processing of his or her personal data at any time. </p>\n\n<p>If the data subject wishes to exercise the right to withdraw the consent, he or she may, at any time, contact any employee of the Ideen³ e.V..</p>\n\n</li>\n</ul>\n<h4>13. Data protection for applications and the application procedures</h4>\n<p>The data controller shall collect and process the personal data of applicants for the purpose of the processing of the application procedure. The processing may also be carried out electronically. This is the case, in particular, if an applicant submits corresponding application documents by e-mail or by means of a web form on the website to the controller. If the data controller concludes an employment contract with an applicant, the submitted data will be stored for the purpose of processing the employment relationship in compliance with legal requirements. If no employment contract is concluded with the applicant by the controller, the application documents shall be automatically erased two months after notification of the refusal decision, provided that no other legitimate interests of the controller are opposed to the erasure. Other legitimate interest in this relation is, e.g. a burden of proof in a procedure under the General Equal Treatment Act (AGG).</p>\n\n<h4>14. Data protection provisions about the application and use of Matomo</h4>\n<p>On this website, the controller has integrated the Matomo component. Matomo is an open-source software tool for web analysis. Web analysis is the collection, gathering and evaluation of data on the behavior of visitors from Internet sites. A web analysis tool collects, inter alia, data on the website from which a data subject came to a website (so-called referrer), which pages of the website were accessed or how often and for which period of time a sub-page was viewed. A web analysis is mainly used for the optimization of a website and the cost-benefit analysis of Internet advertising.</p>\n\n<p>The software is operated on the server of the controller, the data protection-sensitive log files are stored exclusively on this server.</p>\n\n<p>The purpose of the Matomo component is the analysis of the visitor flows on our website. The controller uses the obtained data and information, inter alia, to evaluate the use of this website in order to compile online reports, which show the activities on our Internet pages.</p>\n\n<p>Matomo sets a cookie on the information technology system of the data subject. The definition of cookies is explained above. With the setting of the cookie, an analysis of the use of our website is enabled. With each call-up to one of the individual pages of this website, the Internet browser on the information technology system of the data subject is automatically through the Matomo component prompted to submit data for the purpose of online analysis to our server. During the course of this technical procedure, we obtain knowledge about personal information, such as the IP address of the data subject, which serves to understand the origin of visitors and clicks.</p>\n\n<p>The cookie is used to store personal information, such as the access time, the location from which access was made, and the frequency of visits to our website. With each visit of our Internet pages, these personal data, including the IP address of the Internet access used by the data subject, are transferred to our server. These personal data will be stored by us. We do not forward this personal data to third parties.</p>\n\n<p>The data subject may, as stated above, prevent the setting of cookies through our website at any time by means of a corresponding adjustment of the web browser used and thus permanently deny the setting of cookies. Such an adjustment to the used Internet browser would also prevent Matomo from setting a cookie on the information technology system of the data subject. In addition, cookies already in use by Matomo may be deleted at any time via a web browser or other software programs.</p>\n\n<p>In addition, the data subject has the possibility of objecting to a collection of data relating to a use of this Internet site that are generated by Matomo as well as the processing of these data by Matomo and the chance to preclude any such. For this, the data subject must set a 'Do Not Track' option in the browser.</p>\n\n<p>With each setting of the opt-out cookie, however, there is the possibility that the websites of the controller are no longer fully usable for the data subject.</p>\n\n<p>Further information and the applicable data protection provisions of Matomo may be retrieved under https://matomo.org/privacy/.</p>\n\n<h4>15. Legal basis for the processing </h4>\n<p>Art. 6(1) lit. a GDPR serves as the legal basis for processing operations for which we obtain consent for a specific processing purpose. If the processing of personal data is necessary for the performance of a contract to which the data subject is party, as is the case, for example, when processing operations are necessary for the supply of goods or to provide any other service, the processing is based on Article 6(1) lit. b GDPR. The same applies to such processing operations which are necessary for carrying out pre-contractual measures, for example in the case of inquiries concerning our products or services. Is our company subject to a legal obligation by which processing of personal data is required, such as for the fulfillment of tax obligations, the processing is based on Art. 6(1) lit. c GDPR.\nIn rare cases, the processing of personal data may be necessary to protect the vital interests of the data subject or of another natural person. This would be the case, for example, if a visitor were injured in our company and his name, age, health insurance data or other vital information would have to be passed on to a doctor, hospital or other third party. Then the processing would be based on Art. 6(1) lit. d GDPR.\nFinally, processing operations could be based on Article 6(1) lit. f GDPR. This legal basis is used for processing operations which are not covered by any of the abovementioned legal grounds, if processing is necessary for the purposes of the legitimate interests pursued by our company or by a third party, except where such interests are overridden by the interests or fundamental rights and freedoms of the data subject which require protection of personal data. Such processing operations are particularly permissible because they have been specifically mentioned by the European legislator. He considered that a legitimate interest could be assumed if the data subject is a client of the controller (Recital 47 Sentence 2 GDPR).\n</p>\n\n<h4>16. The legitimate interests pursued by the controller or by a third party</h4>\n<p>Where the processing of personal data is based on Article 6(1) lit. f GDPR our legitimate interest is to carry out our business in favor of the well-being of all our employees and the shareholders.</p>\n\n<h4>17. Period for which the personal data will be stored</h4>\n<p>The criteria used to determine the period of storage of personal data is the respective statutory retention period. After expiration of that period, the corresponding data is routinely deleted, as long as it is no longer necessary for the fulfillment of the contract or the initiation of a contract.</p>\n\n<h4>18. Provision of personal data as statutory or contractual requirement; Requirement necessary to enter into a contract; Obligation of the data subject to provide the personal data; possible consequences of failure to provide such data </h4>\n<p>We clarify that the provision of personal data is partly required by law (e.g. tax regulations) or can also result from contractual provisions (e.g. information on the contractual partner).\n\nSometimes it may be necessary to conclude a contract that the data subject provides us with personal data, which must subsequently be processed by us. The data subject is, for example, obliged to provide us with personal data when our company signs a contract with him or her. The non-provision of the personal data would have the consequence that the contract with the data subject could not be concluded.\n\nBefore personal data is provided by the data subject, the data subject must contact any employee. The employee clarifies to the data subject whether the provision of the personal data is required by law or contract or is necessary for the conclusion of the contract, whether there is an obligation to provide the personal data and the consequences of non-provision of the personal data.\n</p>\n\n<h4>19. Existence of automated decision-making</h4>\n<p>As a responsible company, we do not use automatic decision-making or profiling.</p>\n\n<p>This Privacy Policy has been generated by the Privacy Policy Generator of the <a href='https://dg-datenschutz.de/services/external-data-protection-officer/?lang=en'>External Data Protection Officers</a> that was developed in cooperation with the <a href='https://www.wbs-law.de/eng/practice-areas/media-law/'>Media Law Lawyers</a> from WBS-LAW.\n</p>\n\n"
+    "title": "Declaración de privacidad",
+    "text": "<p>Wir freuen uns sehr über Ihr Interesse an unserem Unternehmen. Datenschutz hat einen besonders hohen Stellenwert für die Geschäftsleitung von Ideen³ e.V.. All unsere Software ist Open Source und für Sie jeder Zeit vollständig nachvollziebar. Wir nutzen niemals kommerzielle Werbe- oder Tracking-Tools und speichern lediglich Klickzahlen zu den Einträgen, um Aussagen über die Relevant einzelner Beiträge treffen zu können. Ein aktives Nutzertracking findet nie statt.\n\nEine Nutzung der Internetseiten von Ideen³ e.V. ist grundsätzlich ohne jede Angabe personenbezogener Daten möglich. Sofern eine betroffene Person besondere Services unseres Unternehmens über unsere Internetseite in Anspruch nehmen möchte, könnte jedoch eine Verarbeitung personenbezogener Daten erforderlich werden. Ist die Verarbeitung personenbezogener Daten erforderlich und besteht für eine solche Verarbeitung keine gesetzliche Grundlage, holen wir generell eine Einwilligung der betroffenen Person ein.</p>\n\n<p>Die Verarbeitung personenbezogener Daten, beispielsweise des Namens, der Anschrift, E-Mail-Adresse oder Telefonnummer einer betroffenen Person, erfolgt stets im Einklang mit der Datenschutz-Grundverordnung und in Übereinstimmung mit den für die Ideen³ e.V. geltenden landesspezifischen Datenschutzbestimmungen. Mittels dieser Datenschutzerklärung möchte unser Unternehmen die Öffentlichkeit über Art, Umfang und Zweck der von uns erhobenen, genutzten und verarbeiteten personenbezogenen Daten informieren. Ferner werden betroffene Personen mittels dieser Datenschutzerklärung über die ihnen zustehenden Rechte aufgeklärt.</p>\n\n<p>Die Ideen³ e.V. hat als für die Verarbeitung Verantwortlicher zahlreiche technische und organisatorische Maßnahmen umgesetzt, um einen möglichst lückenlosen Schutz der über diese Internetseite verarbeiteten personenbezogenen Daten sicherzustellen. Dennoch können Internetbasierte Datenübertragungen grundsätzlich Sicherheitslücken aufweisen, sodass ein absoluter Schutz nicht gewährleistet werden kann. Aus diesem Grund steht es jeder betroffenen Person frei, personenbezogene Daten auch auf alternativen Wegen, beispielsweise telefonisch, an uns zu übermitteln.</p>\n\n<h4>1. Begriffsbestimmungen</h4>\n<p>Die Datenschutzerklärung der Ideen³ e.V. beruht auf den Begrifflichkeiten, die durch den Europäischen Richtlinien- und Verordnungsgeber beim Erlass der Datenschutz-Grundverordnung (DS-GVO) verwendet wurden. Unsere Datenschutzerklärung soll sowohl für die Öffentlichkeit als auch für unsere Kunden und Geschäftspartner einfach lesbar und verständlich sein. Um dies zu gewährleisten, möchten wir vorab die verwendeten Begrifflichkeiten erläutern.</p>\n\n<p>Wir verwenden in dieser Datenschutzerklärung unter anderem die folgenden Begriffe:</p>\n\n<ul style='list-style: none'>\n<li><h4>a)    personenbezogene Daten</h4>\n<p>Personenbezogene Daten sind alle Informationen, die sich auf eine identifizierte oder identifizierbare natürliche Person (im Folgenden „betroffene Person“) beziehen. Als identifizierbar wird eine natürliche Person angesehen, die direkt oder indirekt, insbesondere mittels Zuordnung zu einer Kennung wie einem Namen, zu einer Kennnummer, zu Standortdaten, zu einer Online-Kennung oder zu einem oder mehreren besonderen Merkmalen, die Ausdruck der physischen, physiologischen, genetischen, psychischen, wirtschaftlichen, kulturellen oder sozialen Identität dieser natürlichen Person sind, identifiziert werden kann.</p>\n</li>\n<li><h4>b)    betroffene Person</h4>\n<p>Betroffene Person ist jede identifizierte oder identifizierbare natürliche Person, deren personenbezogene Daten von dem für die Verarbeitung Verantwortlichen verarbeitet werden.</p>\n</li>\n<li><h4>c)    Verarbeitung</h4>\n<p>Verarbeitung ist jeder mit oder ohne Hilfe automatisierter Verfahren ausgeführte Vorgang oder jede solche Vorgangsreihe im Zusammenhang mit personenbezogenen Daten wie das Erheben, das Erfassen, die Organisation, das Ordnen, die Speicherung, die Anpassung oder Veränderung, das Auslesen, das Abfragen, die Verwendung, die Offenlegung durch Übermittlung, Verbreitung oder eine andere Form der Bereitstellung, den Abgleich oder die Verknüpfung, die Einschränkung, das Löschen oder die Vernichtung.</p>\n</li>\n<li><h4>d)    Einschränkung der Verarbeitung</h4>\n<p>Einschränkung der Verarbeitung ist die Markierung gespeicherter personenbezogener Daten mit dem Ziel, ihre künftige Verarbeitung einzuschränken.</p>\n</li>\n<li><h4>e)    Profiling</h4>\n<p>Profiling ist jede Art der automatisierten Verarbeitung personenbezogener Daten, die darin besteht, dass diese personenbezogenen Daten verwendet werden, um bestimmte persönliche Aspekte, die sich auf eine natürliche Person beziehen, zu bewerten, insbesondere, um Aspekte bezüglich Arbeitsleistung, wirtschaftlicher Lage, Gesundheit, persönlicher Vorlieben, Interessen, Zuverlässigkeit, Verhalten, Aufenthaltsort oder Ortswechsel dieser natürlichen Person zu analysieren oder vorherzusagen.</p>\n</li>\n<li><h4>f)     Pseudonymisierung</h4>\n<p>Pseudonymisierung ist die Verarbeitung personenbezogener Daten in einer Weise, auf welche die personenbezogenen Daten ohne Hinzuziehung zusätzlicher Informationen nicht mehr einer spezifischen betroffenen Person zugeordnet werden können, sofern diese zusätzlichen Informationen gesondert aufbewahrt werden und technischen und organisatorischen Maßnahmen unterliegen, die gewährleisten, dass die personenbezogenen Daten nicht einer identifizierten oder identifizierbaren natürlichen Person zugewiesen werden.</p>\n</li>\n<li><h4>g)    Verantwortlicher oder für die Verarbeitung Verantwortlicher</h4>\n<p>Verantwortlicher oder für die Verarbeitung Verantwortlicher ist die natürliche oder juristische Person, Behörde, Einrichtung oder andere Stelle, die allein oder gemeinsam mit anderen über die Zwecke und Mittel der Verarbeitung von personenbezogenen Daten entscheidet. Sind die Zwecke und Mittel dieser Verarbeitung durch das Unionsrecht oder das Recht der Mitgliedstaaten vorgegeben, so kann der Verantwortliche beziehungsweise können die bestimmten Kriterien seiner Benennung nach dem Unionsrecht oder dem Recht der Mitgliedstaaten vorgesehen werden.</p>\n</li>\n<li><h4>h)    Auftragsverarbeiter</h4>\n<p>Auftragsverarbeiter ist eine natürliche oder juristische Person, Behörde, Einrichtung oder andere Stelle, die personenbezogene Daten im Auftrag des Verantwortlichen verarbeitet.</p>\n</li>\n<li><h4>i)      Empfänger</h4>\n<p>Empfänger ist eine natürliche oder juristische Person, Behörde, Einrichtung oder andere Stelle, der personenbezogene Daten offengelegt werden, unabhängig davon, ob es sich bei ihr um einen Dritten handelt oder nicht. Behörden, die im Rahmen eines bestimmten Untersuchungsauftrags nach dem Unionsrecht oder dem Recht der Mitgliedstaaten möglicherweise personenbezogene Daten erhalten, gelten jedoch nicht als Empfänger.</p>\n</li>\n<li><h4>j)      Dritter</h4>\n<p>Dritter ist eine natürliche oder juristische Person, Behörde, Einrichtung oder andere Stelle außer der betroffenen Person, dem Verantwortlichen, dem Auftragsverarbeiter und den Personen, die unter der unmittelbaren Verantwortung des Verantwortlichen oder des Auftragsverarbeiters befugt sind, die personenbezogenen Daten zu verarbeiten.</p>\n</li>\n<li><h4>k)    Einwilligung</h4>\n<p>Einwilligung ist jede von der betroffenen Person freiwillig für den bestimmten Fall in informierter Weise und unmissverständlich abgegebene Willensbekundung in Form einer Erklärung oder einer sonstigen eindeutigen bestätigenden Handlung, mit der die betroffene Person zu verstehen gibt, dass sie mit der Verarbeitung der sie betreffenden personenbezogenen Daten einverstanden ist.</p>\n</li>\n</ul>\n\n<h4>2. Name und Anschrift des für die Verarbeitung Verantwortlichen</h4>\n<p>Verantwortlicher im Sinne der Datenschutz-Grundverordnung, sonstiger in den Mitgliedstaaten der Europäischen Union geltenden Datenschutzgesetze und anderer Bestimmungen mit datenschutzrechtlichem Charakter ist die:</p>\n\n<p>Ideen³ e.V.</p>\n<p>Görreshof 180</p>\n<p>53347 Alfter</p>\n<p>Deutschland</p>\n<p>Tel.: 01573-444 8245</p>\n<p>E-Mail: info@ideenhochdrei.org</p>\n<p>Website: https://www.kartevonmorgen.org</p>\n\n<h4>3. Cookies</h4>\n<p>Die Internetseiten der Ideen³ e.V. verwenden Cookies, **nur sofern Sie sich registrieren oder bei uns anmelden**. Cookies sind Textdateien, welche über einen Internetbrowser auf einem Computersystem abgelegt und gespeichert werden und stellen sicher, dass Sie angemeldet bleiben, auch wenn Sie auf einen Link klicken oder einen neuen Tab öffnen.</p>\n\n<p>Zahlreiche Internetseiten und Server verwenden Cookies. Viele Cookies enthalten eine sogenannte Cookie-ID. Eine Cookie-ID ist eine eindeutige Kennung des Cookies. Sie besteht aus einer Zeichenfolge, durch welche Internetseiten und Server dem konkreten Internetbrowser zugeordnet werden können, in dem das Cookie gespeichert wurde. Dies ermöglicht es den besuchten Internetseiten und Servern, den individuellen Browser der betroffenen Person von anderen Internetbrowsern, die andere Cookies enthalten, zu unterscheiden. Ein bestimmter Internetbrowser kann über die eindeutige Cookie-ID wiedererkannt und identifiziert werden.</p>\n\n<p>Durch den Einsatz von Cookies kann die Ideen³ e.V. den Nutzern dieser Internetseite nutzerfreundlichere Services bereitstellen, die ohne die Cookie-Setzung nicht möglich wären.</p>\n\n<p>Mittels eines Cookies können die Informationen und Angebote auf unserer Internetseite im Sinne des Benutzers optimiert werden. Cookies ermöglichen uns, wie bereits erwähnt, die Benutzer unserer Internetseite wiederzuerkennen. Zweck dieser Wiedererkennung ist es, den Nutzern die Verwendung unserer Internetseite zu erleichtern. Der Benutzer einer Internetseite, die Cookies verwendet, muss beispielsweise nicht bei jedem Besuch der Internetseite erneut seine Zugangsdaten eingeben, weil dies von der Internetseite und dem auf dem Computersystem des Benutzers abgelegten Cookie übernommen wird. Ein weiteres Beispiel ist das Cookie eines Warenkorbes im Online-Shop. Der Online-Shop merkt sich die Artikel, die ein Kunde in den virtuellen Warenkorb gelegt hat, über ein Cookie.</p>\n\n<p>Die betroffene Person kann die Setzung von Cookies durch unsere Internetseite jederzeit mittels einer entsprechenden Einstellung des genutzten Internetbrowsers verhindern und damit der Setzung von Cookies dauerhaft widersprechen. Ferner können bereits gesetzte Cookies jederzeit über einen Internetbrowser oder andere Softwareprogramme gelöscht werden. Dies ist in allen gängigen Internetbrowsern möglich. Deaktiviert die betroffene Person die Setzung von Cookies in dem genutzten Internetbrowser, sind unter Umständen nicht alle Funktionen unserer Internetseite vollumfänglich nutzbar.</p>\n\n<h4>4. Erfassung von allgemeinen Daten und Informationen</h4>\n<p>Die Internetseite der Ideen³ e.V. erfasst mit jedem Aufruf der Internetseite durch eine betroffene Person oder ein automatisiertes System eine Reihe von allgemeinen Daten und Informationen. Diese allgemeinen Daten und Informationen werden in den Logfiles des Servers gespeichert. Erfasst werden können die (1) verwendeten Browsertypen und Versionen, (2) das vom zugreifenden System verwendete Betriebssystem, (3) die Internetseite, von welcher ein zugreifendes System auf unsere Internetseite gelangt (sogenannte Referrer), (4) die Unterwebseiten, welche über ein zugreifendes System auf unserer Internetseite angesteuert werden, (5) das Datum und die Uhrzeit eines Zugriffs auf die Internetseite, (6) eine Internet-Protokoll-Adresse (IP-Adresse), (7) der Internet-Service-Provider des zugreifenden Systems und (8) sonstige ähnliche Daten und Informationen, die der Gefahrenabwehr im Falle von Angriffen auf unsere informationstechnologischen Systeme dienen.</p>\n\n<p>Bei der Nutzung dieser allgemeinen Daten und Informationen zieht die Ideen³ e.V. keine Rückschlüsse auf die betroffene Person. Diese Informationen werden vielmehr benötigt, um (1) die Inhalte unserer Internetseite korrekt auszuliefern, (2) die Inhalte unserer Internetseite sowie die Werbung für diese zu optimieren, (3) die dauerhafte Funktionsfähigkeit unserer informationstechnologischen Systeme und der Technik unserer Internetseite zu gewährleisten sowie (4) um Strafverfolgungsbehörden im Falle eines Cyberangriffes die zur Strafverfolgung notwendigen Informationen bereitzustellen. Diese anonym erhobenen Daten und Informationen werden durch die Ideen³ e.V. daher einerseits statistisch und ferner mit dem Ziel ausgewertet, den Datenschutz und die Datensicherheit in unserem Unternehmen zu erhöhen, um letztlich ein optimales Schutzniveau für die von uns verarbeiteten personenbezogenen Daten sicherzustellen. Die anonymen Daten der Server-Logfiles werden getrennt von allen durch eine betroffene Person angegebenen personenbezogenen Daten gespeichert.</p>\n\n<h4>5. Registrierung auf unserer Internetseite</h4>\n<p>Die betroffene Person hat die Möglichkeit, sich auf der Internetseite des für die Verarbeitung Verantwortlichen unter Angabe von personenbezogenen Daten zu registrieren. Welche personenbezogenen Daten dabei an den für die Verarbeitung Verantwortlichen übermittelt werden, ergibt sich aus der jeweiligen Eingabemaske, die für die Registrierung verwendet wird. Die von der betroffenen Person eingegebenen personenbezogenen Daten werden ausschließlich für die interne Verwendung bei dem für die Verarbeitung Verantwortlichen und für eigene Zwecke erhoben und gespeichert. Der für die Verarbeitung Verantwortliche kann die Weitergabe an einen oder mehrere Auftragsverarbeiter, beispielsweise einen Paketdienstleister, veranlassen, der die personenbezogenen Daten ebenfalls ausschließlich für eine interne Verwendung, die dem für die Verarbeitung Verantwortlichen zuzurechnen ist, nutzt.</p>\n\n<p>Durch eine Registrierung auf der Internetseite des für die Verarbeitung Verantwortlichen wird ferner die vom Internet-Service-Provider (ISP) der betroffenen Person vergebene IP-Adresse, das Datum sowie die Uhrzeit der Registrierung gespeichert. Die Speicherung dieser Daten erfolgt vor dem Hintergrund, dass nur so der Missbrauch unserer Dienste verhindert werden kann, und diese Daten im Bedarfsfall ermöglichen, begangene Straftaten aufzuklären. Insofern ist die Speicherung dieser Daten zur Absicherung des für die Verarbeitung Verantwortlichen erforderlich. Eine Weitergabe dieser Daten an Dritte erfolgt grundsätzlich nicht, sofern keine gesetzliche Pflicht zur Weitergabe besteht oder die Weitergabe der Strafverfolgung dient.</p>\n\n<p>Die Registrierung der betroffenen Person unter freiwilliger Angabe personenbezogener Daten dient dem für die Verarbeitung Verantwortlichen dazu, der betroffenen Person Inhalte oder Leistungen anzubieten, die aufgrund der Natur der Sache nur registrierten Benutzern angeboten werden können. Registrierten Personen steht die Möglichkeit frei, die bei der Registrierung angegebenen personenbezogenen Daten jederzeit abzuändern oder vollständig aus dem Datenbestand des für die Verarbeitung Verantwortlichen löschen zu lassen.</p>\n\n<p>Der für die Verarbeitung Verantwortliche erteilt jeder betroffenen Person jederzeit auf Anfrage Auskunft darüber, welche personenbezogenen Daten über die betroffene Person gespeichert sind. Ferner berichtigt oder löscht der für die Verarbeitung Verantwortliche personenbezogene Daten auf Wunsch oder Hinweis der betroffenen Person, soweit dem keine gesetzlichen Aufbewahrungspflichten entgegenstehen. Die Gesamtheit der Mitarbeiter des für die Verarbeitung Verantwortlichen stehen der betroffenen Person in diesem Zusammenhang als Ansprechpartner zur Verfügung.</p>\n\n<h4>6. Abonnement unseres Newsletters</h4>\n<p>Auf der Internetseite der Ideen³ e.V. wird den Benutzern die Möglichkeit eingeräumt, den Newsletter unseres Unternehmens zu abonnieren. Welche personenbezogenen Daten bei der Bestellung des Newsletters an den für die Verarbeitung Verantwortlichen übermittelt werden, ergibt sich aus der hierzu verwendeten Eingabemaske.</p>\n\n<p>Die Ideen³ e.V. informiert ihre Kunden und Geschäftspartner in regelmäßigen Abständen im Wege eines Newsletters über Angebote des Unternehmens. Der Newsletter unseres Unternehmens kann von der betroffenen Person grundsätzlich nur dann empfangen werden, wenn (1) die betroffene Person über eine gültige E-Mail-Adresse verfügt und (2) die betroffene Person sich für den Newsletterversand registriert. An die von einer betroffenen Person erstmalig für den Newsletterversand eingetragene E-Mail-Adresse wird aus rechtlichen Gründen eine Bestätigungsmail im Double-Opt-In-Verfahren versendet. Diese Bestätigungsmail dient der Überprüfung, ob der Inhaber der E-Mail-Adresse als betroffene Person den Empfang des Newsletters autorisiert hat.</p>\n\n<p>Bei der Anmeldung zum Newsletter speichern wir ferner die vom Internet-Service-Provider (ISP) vergebene IP-Adresse des von der betroffenen Person zum Zeitpunkt der Anmeldung verwendeten Computersystems sowie das Datum und die Uhrzeit der Anmeldung. Die Erhebung dieser Daten ist erforderlich, um den(möglichen) Missbrauch der E-Mail-Adresse einer betroffenen Person zu einem späteren Zeitpunkt nachvollziehen zu können und dient deshalb der rechtlichen Absicherung des für die Verarbeitung Verantwortlichen.</p>\n\n<p>Die im Rahmen einer Anmeldung zum Newsletter erhobenen personenbezogenen Daten werden ausschließlich zum Versand unseres Newsletters verwendet. Ferner könnten Abonnenten des Newsletters per E-Mail informiert werden, sofern dies für den Betrieb des Newsletter-Dienstes oder eine diesbezügliche Registrierung erforderlich ist, wie dies im Falle von Änderungen am Newsletterangebot oder bei der Veränderung der technischen Gegebenheiten der Fall sein könnte. Es erfolgt keine Weitergabe der im Rahmen des Newsletter-Dienstes erhobenen personenbezogenen Daten an Dritte. Das Abonnement unseres Newsletters kann durch die betroffene Person jederzeit gekündigt werden. Die Einwilligung in die Speicherung personenbezogener Daten, die die betroffene Person uns für den Newsletterversand erteilt hat, kann jederzeit widerrufen werden. Zum Zwecke des Widerrufs der Einwilligung findet sich in jedem Newsletter ein entsprechender Link. Ferner besteht die Möglichkeit, sich jederzeit auch direkt auf der Internetseite des für die Verarbeitung Verantwortlichen vom Newsletterversand abzumelden oder dies dem für die Verarbeitung Verantwortlichen auf andere Weise mitzuteilen.</p>\n\n<h4>7. Newsletter-Tracking</h4>\n<p>Die Newsletter der Ideen³ e.V. enthalten sogenannte Zählpixel. Ein Zählpixel ist eine Miniaturgrafik, die in solche E-Mails eingebettet wird, welche im HTML-Format versendet werden, um eine Logdatei-Aufzeichnung und eine Logdatei-Analyse zu ermöglichen. Dadurch kann eine statistische Auswertung des Erfolges oder Misserfolges von Online-Marketing-Kampagnen durchgeführt werden. Anhand des eingebetteten Zählpixels kann die Ideen³ e.V. erkennen, ob und wann eine E-Mail von einer betroffenen Person geöffnet wurde und welche in der E-Mail befindlichen Links von der betroffenen Person aufgerufen wurden.</p>\n\n<p>Solche über die in den Newslettern enthaltenen Zählpixel erhobenen personenbezogenen Daten, werden von dem für die Verarbeitung Verantwortlichen gespeichert und ausgewertet, um den Newsletterversand zu optimieren und den Inhalt zukünftiger Newsletter noch besser den Interessen der betroffenen Person anzupassen. Diese personenbezogenen Daten werden nicht an Dritte weitergegeben. Betroffene Personen sind jederzeit berechtigt, die diesbezügliche gesonderte, über das Double-Opt-In-Verfahren abgegebene Einwilligungserklärung zu widerrufen. Nach einem Widerruf werden diese personenbezogenen Daten von dem für die Verarbeitung Verantwortlichen gelöscht. Eine Abmeldung vom Erhalt des Newsletters deutet die Ideen³ e.V. automatisch als Widerruf.</p>\n\n<h4>8. Kontaktmöglichkeit über die Internetseite</h4>\n<p>Die Internetseite der Ideen³ e.V. enthält aufgrund von gesetzlichen Vorschriften Angaben, die eine schnelle elektronische Kontaktaufnahme zu unserem Unternehmen sowie eine unmittelbare Kommunikation mit uns ermöglichen, was ebenfalls eine allgemeine Adresse der sogenannten elektronischen Post (E-Mail-Adresse) umfasst. Sofern eine betroffene Person per E-Mail oder über ein Kontaktformular den Kontakt mit dem für die Verarbeitung Verantwortlichen aufnimmt, werden die von der betroffenen Person übermittelten personenbezogenen Daten automatisch gespeichert. Solche auf freiwilliger Basis von einer betroffenen Person an den für die Verarbeitung Verantwortlichen übermittelten personenbezogenen Daten werden für Zwecke der Bearbeitung oder der Kontaktaufnahme zur betroffenen Person gespeichert. Es erfolgt keine Weitergabe dieser personenbezogenen Daten an Dritte.</p>\n\n<h4>9. Kommentarfunktion im Blog auf der Internetseite</h4>\n<p>Die Ideen³ e.V. bietet den Nutzern auf einem Blog, der sich auf der Internetseite des für die Verarbeitung Verantwortlichen befindet, die Möglichkeit, individuelle Kommentare zu einzelnen Blog-Beiträgen zu hinterlassen. Ein Blog ist ein auf einer Internetseite geführtes, in der Regel öffentlich einsehbares Portal, in welchem eine oder mehrere Personen, die Blogger oder Web-Blogger genannt werden, Artikel posten oder Gedanken in sogenannten Blogposts niederschreiben können. Die Blogposts können in der Regel von Dritten kommentiert werden.</p>\n\n<p>Hinterlässt eine betroffene Person einen Kommentar in dem auf dieser Internetseite veröffentlichten Blog, werden neben den von der betroffenen Person hinterlassenen Kommentaren auch Angaben zum Zeitpunkt der Kommentareingabe sowie zu dem von der betroffenen Person gewählten Nutzernamen (Pseudonym) gespeichert und veröffentlicht. Ferner wird die vom Internet-Service-Provider (ISP) der betroffenen Person vergebene IP-Adresse mitprotokolliert. Diese Speicherung der IP-Adresse erfolgt aus Sicherheitsgründen und für den Fall, dass die betroffene Person durch einen abgegebenen Kommentar die Rechte Dritter verletzt oder rechtswidrige Inhalte postet. Die Speicherung dieser personenbezogenen Daten erfolgt daher im eigenen Interesse des für die Verarbeitung Verantwortlichen, damit sich dieser im Falle einer Rechtsverletzung gegebenenfalls exkulpieren könnte. Es erfolgt keine Weitergabe dieser erhobenen personenbezogenen Daten an Dritte, sofern eine solche Weitergabe nicht gesetzlich vorgeschrieben ist oder der Rechtsverteidigung des für die Verarbeitung Verantwortlichen dient.</p>\n\n<h4>10. Abonnement von Kommentaren im Blog auf der Internetseite</h4>\n<p>Die im Blog der Ideen³ e.V. abgegebenen Kommentare können grundsätzlich von Dritten abonniert werden. Insbesondere besteht die Möglichkeit, dass ein Kommentator die seinem Kommentar nachfolgenden Kommentare zu einem bestimmten Blog-Beitrag abonniert.</p>\n\n<p>Sofern sich eine betroffene Person für die Option entscheidet, Kommentare zu abonnieren, versendet der für die Verarbeitung Verantwortliche eine automatische Bestätigungsmail, um im Double-Opt-In-Verfahren zu überprüfen, ob sich wirklich der Inhaber der angegebenen E-Mail-Adresse für diese Option entschieden hat. Die Option zum Abonnement von Kommentaren kann jederzeit beendet werden.</p>\n\n<h4>11. Routinemäßige Löschung und Sperrung von personenbezogenen Daten</h4>\n<p>Der für die Verarbeitung Verantwortliche verarbeitet und speichert personenbezogene Daten der betroffenen Person nur für den Zeitraum, der zur Erreichung des Speicherungszwecks erforderlich ist oder sofern dies durch den Europäischen Richtlinien- und Verordnungsgeber oder einen anderen Gesetzgeber in Gesetzen oder Vorschriften, welchen der für die Verarbeitung Verantwortliche unterliegt, vorgesehen wurde.</p>\n\n<p>Entfällt der Speicherungszweck oder läuft eine vom Europäischen Richtlinien- und Verordnungsgeber oder einem anderen zuständigen Gesetzgeber vorgeschriebene Speicherfrist ab, werden die personenbezogenen Daten routinemäßig und entsprechend den gesetzlichen Vorschriften gesperrt oder gelöscht.</p>\n\n<h4>12. Rechte der betroffenen Person</h4>\n<ul style='list-style: none;'>\n<li><h4>a)    Recht auf Bestätigung</h4>\n<p>Jede betroffene Person hat das vom Europäischen Richtlinien- und Verordnungsgeber eingeräumte Recht, von dem für die Verarbeitung Verantwortlichen eine Bestätigung darüber zu verlangen, ob sie betreffende personenbezogene Daten verarbeitet werden. Möchte eine betroffene Person dieses Bestätigungsrecht in Anspruch nehmen, kann sie sich hierzu jederzeit an einen Mitarbeiter des für die Verarbeitung Verantwortlichen wenden.</p>\n</li>\n<li><h4>b)    Recht auf Auskunft</h4>\n<p>Jede von der Verarbeitung personenbezogener Daten betroffene Person hat das vom Europäischen Richtlinien- und Verordnungsgeber gewährte Recht, jederzeit von dem für die Verarbeitung Verantwortlichen unentgeltliche Auskunft über die zu seiner Person gespeicherten personenbezogenen Daten und eine Kopie dieser Auskunft zu erhalten. Ferner hat der Europäische Richtlinien- und Verordnungsgeber der betroffenen Person Auskunft über folgende Informationen zugestanden:</p>\n\n<ul style='list-style: none;'>\n<li>die Verarbeitungszwecke</li>\n<li>die Kategorien personenbezogener Daten, die verarbeitet werden</li>\n<li>die Empfänger oder Kategorien von Empfängern, gegenüber denen die personenbezogenen Daten offengelegt worden sind oder noch offengelegt werden, insbesondere bei Empfängern in Drittländern oder bei internationalen Organisationen</li>\n<li>falls möglich die geplante Dauer, für die die personenbezogenen Daten gespeichert werden, oder, falls dies nicht möglich ist, die Kriterien für die Festlegung dieser Dauer</li>\n<li>das Bestehen eines Rechts auf Berichtigung oder Löschung der sie betreffenden personenbezogenen Daten oder auf Einschränkung der Verarbeitung durch den Verantwortlichen oder eines Widerspruchsrechts gegen diese Verarbeitung</li>\n<li>das Bestehen eines Beschwerderechts bei einer Aufsichtsbehörde</li>\n<li>wenn die personenbezogenen Daten nicht bei der betroffenen Person erhoben werden: Alle verfügbaren Informationen über die Herkunft der Daten</li>\n<li>das Bestehen einer automatisierten Entscheidungsfindung einschließlich Profiling gemäß Artikel 22 Abs.1 und 4 DS-GVO und — zumindest in diesen Fällen — aussagekräftige Informationen über die involvierte Logik sowie die Tragweite und die angestrebten Auswirkungen einer derartigen Verarbeitung für die betroffene Person</li>\n\n</ul>\n<p>Ferner steht der betroffenen Person ein Auskunftsrecht darüber zu, ob personenbezogene Daten an ein Drittland oder an eine internationale Organisation übermittelt wurden. Sofern dies der Fall ist, so steht der betroffenen Person im Übrigen das Recht zu, Auskunft über die geeigneten Garantien im Zusammenhang mit der Übermittlung zu erhalten.</p>\n\n<p>Möchte eine betroffene Person dieses Auskunftsrecht in Anspruch nehmen, kann sie sich hierzu jederzeit an einen Mitarbeiter des für die Verarbeitung Verantwortlichen wenden.</p>\n</li>\n<li><h4>c)    Recht auf Berichtigung</h4>\n<p>Jede von der Verarbeitung personenbezogener Daten betroffene Person hat das vom Europäischen Richtlinien- und Verordnungsgeber gewährte Recht, die unverzügliche Berichtigung sie betreffender unrichtiger personenbezogener Daten zu verlangen. Ferner steht der betroffenen Person das Recht zu, unter Berücksichtigung der Zwecke der Verarbeitung, die Vervollständigung unvollständiger personenbezogener Daten — auch mittels einer ergänzenden Erklärung — zu verlangen.</p>\n\n<p>Möchte eine betroffene Person dieses Berichtigungsrecht in Anspruch nehmen, kann sie sich hierzu jederzeit an einen Mitarbeiter des für die Verarbeitung Verantwortlichen wenden.</p></li>\n<li>\n<h4>d)    Recht auf Löschung (Recht auf Vergessen werden)</h4>\n<p>Jede von der Verarbeitung personenbezogener Daten betroffene Person hat das vom Europäischen Richtlinien- und Verordnungsgeber gewährte Recht, von dem Verantwortlichen zu verlangen, dass die sie betreffenden personenbezogenen Daten unverzüglich gelöscht werden, sofern einer der folgenden Gründe zutrifft und soweit die Verarbeitung nicht erforderlich ist:</p>\n\n<ul style='list-style: none;'>\n<li>Die personenbezogenen Daten wurden für solche Zwecke erhoben oder auf sonstige Weise verarbeitet, für welche sie nicht mehr notwendig sind.</li>\n<li>Die betroffene Person widerruft ihre Einwilligung, auf die sich die Verarbeitung gemäß Art. 6 Abs. 1 Buchstabe a DS-GVO oder Art. 9 Abs. 2 Buchstabe a DS-GVO stützte, und es fehlt an einer anderweitigen Rechtsgrundlage für die Verarbeitung.</li>\n<li>Die betroffene Person legt gemäß Art. 21 Abs. 1 DS-GVO Widerspruch gegen die Verarbeitung ein, und es liegen keine vorrangigen berechtigten Gründe für die Verarbeitung vor, oder die betroffene Person legt gemäß Art. 21 Abs. 2 DS-GVO Widerspruch gegen die Verarbeitung ein.</li>\n<li>Die personenbezogenen Daten wurden unrechtmäßig verarbeitet.</li>\n<li>Die Löschung der personenbezogenen Daten ist zur Erfüllung einer rechtlichen Verpflichtung nach dem Unionsrecht oder dem Recht der Mitgliedstaaten erforderlich, dem der Verantwortliche unterliegt.</li>\n<li>Die personenbezogenen Daten wurden in Bezug auf angebotene Dienste der Informationsgesellschaft gemäß Art. 8 Abs. 1 DS-GVO erhoben.</li>\n\n</ul>\n<p>Sofern einer der oben genannten Gründe zutrifft und eine betroffene Person die Löschung von personenbezogenen Daten, die bei der Ideen³ e.V. gespeichert sind, veranlassen möchte, kann sie sich hierzu jederzeit an einen Mitarbeiter des für die Verarbeitung Verantwortlichen wenden. Der Mitarbeiter der Ideen³ e.V. wird veranlassen, dass dem Löschverlangen unverzüglich nachgekommen wird.</p>\n\n<p>Wurden die personenbezogenen Daten von der Ideen³ e.V. öffentlich gemacht und ist unser Unternehmen als Verantwortlicher gemäß Art. 17 Abs. 1 DS-GVO zur Löschung der personenbezogenen Daten verpflichtet, so trifft die Ideen³ e.V. unter Berücksichtigung der verfügbaren Technologie und der Implementierungskosten angemessene Maßnahmen, auch technischer Art, um andere für die Datenverarbeitung Verantwortliche, welche die veröffentlichten personenbezogenen Daten verarbeiten, darüber in Kenntnis zu setzen, dass die betroffene Person von diesen anderen für die Datenverarbeitung Verantwortlichen die Löschung sämtlicher Links zu diesen personenbezogenen Daten oder von Kopien oder Replikationen dieser personenbezogenen Daten verlangt hat, soweit die Verarbeitung nicht erforderlich ist. Der Mitarbeiter der Ideen³ e.V. wird im Einzelfall das Notwendige veranlassen.</p>\n</li>\n<li><h4>e)    Recht auf Einschränkung der Verarbeitung</h4>\n<p>Jede von der Verarbeitung personenbezogener Daten betroffene Person hat das vom Europäischen Richtlinien- und Verordnungsgeber gewährte Recht, von dem Verantwortlichen die Einschränkung der Verarbeitung zu verlangen, wenn eine der folgenden Voraussetzungen gegeben ist:</p>\n\n<ul style='list-style: none;'>\n<li>Die Richtigkeit der personenbezogenen Daten wird von der betroffenen Person bestritten, und zwar für eine Dauer, die es dem Verantwortlichen ermöglicht, die Richtigkeit der personenbezogenen Daten zu überprüfen.</li>\n<li>Die Verarbeitung ist unrechtmäßig, die betroffene Person lehnt die Löschung der personenbezogenen Daten ab und verlangt stattdessen die Einschränkung der Nutzung der personenbezogenen Daten.</li>\n<li>Der Verantwortliche benötigt die personenbezogenen Daten für die Zwecke der Verarbeitung nicht länger, die betroffene Person benötigt sie jedoch zur Geltendmachung, Ausübung oder Verteidigung von Rechtsansprüchen.</li>\n<li>Die betroffene Person hat Widerspruch gegen die Verarbeitung gem. Art. 21 Abs. 1 DS-GVO eingelegt und es steht noch nicht fest, ob die berechtigten Gründe des Verantwortlichen gegenüber denen der betroffenen Person überwiegen.</li>\n\n</ul>\n<p>Sofern eine der oben genannten Voraussetzungen gegeben ist und eine betroffene Person die Einschränkung von personenbezogenen Daten, die bei der Ideen³ e.V. gespeichert sind, verlangen möchte, kann sie sich hierzu jederzeit an einen Mitarbeiter des für die Verarbeitung Verantwortlichen wenden. Der Mitarbeiter der Ideen³ e.V. wird die Einschränkung der Verarbeitung veranlassen.</p>\n</li>\n<li><h4>f)     Recht auf Datenübertragbarkeit</h4>\n<p>Jede von der Verarbeitung personenbezogener Daten betroffene Person hat das vom Europäischen Richtlinien- und Verordnungsgeber gewährte Recht, die sie betreffenden personenbezogenen Daten, welche durch die betroffene Person einem Verantwortlichen bereitgestellt wurden, in einem strukturierten, gängigen und maschinenlesbaren Format zu erhalten. Sie hat außerdem das Recht, diese Daten einem anderen Verantwortlichen ohne Behinderung durch den Verantwortlichen, dem die personenbezogenen Daten bereitgestellt wurden, zu übermitteln, sofern die Verarbeitung auf der Einwilligung gemäß Art. 6 Abs. 1 Buchstabe a DS-GVO oder Art. 9 Abs. 2 Buchstabe a DS-GVO oder auf einem Vertrag gemäß Art. 6 Abs. 1 Buchstabe b DS-GVO beruht und die Verarbeitung mithilfe automatisierter Verfahren erfolgt, sofern die Verarbeitung nicht für die Wahrnehmung einer Aufgabe erforderlich ist, die im öffentlichen Interesse liegt oder in Ausübung öffentlicher Gewalt erfolgt, welche dem Verantwortlichen übertragen wurde.</p>\n\n<p>Ferner hat die betroffene Person bei der Ausübung ihres Rechts auf Datenübertragbarkeit gemäß Art. 20 Abs. 1 DS-GVO das Recht, zu erwirken, dass die personenbezogenen Daten direkt von einem Verantwortlichen an einen anderen Verantwortlichen übermittelt werden, soweit dies technisch machbar ist und sofern hiervon nicht die Rechte und Freiheiten anderer Personen beeinträchtigt werden.</p>\n\n<p>Zur Geltendmachung des Rechts auf Datenübertragbarkeit kann sich die betroffene Person jederzeit an einen Mitarbeiter der Ideen³ e.V. wenden.</p>\n\n</li>\n<li>\n<h4>g)    Recht auf Widerspruch</h4>\n<p>Jede von der Verarbeitung personenbezogener Daten betroffene Person hat das vom Europäischen Richtlinien- und Verordnungsgeber gewährte Recht, aus Gründen, die sich aus ihrer besonderen Situation ergeben, jederzeit gegen die Verarbeitung sie betreffender personenbezogener Daten, die aufgrund von Art. 6 Abs. 1 Buchstaben e oder f DS-GVO erfolgt, Widerspruch einzulegen. Dies gilt auch für ein auf diese Bestimmungen gestütztes Profiling.</p>\n\n<p>Die Ideen³ e.V. verarbeitet die personenbezogenen Daten im Falle des Widerspruchs nicht mehr, es sei denn, wir können zwingende schutzwürdige Gründe für die Verarbeitung nachweisen, die den Interessen, Rechten und Freiheiten der betroffenen Person überwiegen, oder die Verarbeitung dient der Geltendmachung, Ausübung oder Verteidigung von Rechtsansprüchen.</p>\n\n<p>Verarbeitet die Ideen³ e.V. personenbezogene Daten, um Direktwerbung zu betreiben, so hat die betroffene Person das Recht, jederzeit Widerspruch gegen die Verarbeitung der personenbezogenen Daten zum Zwecke derartiger Werbung einzulegen. Dies gilt auch für das Profiling, soweit es mit solcher Direktwerbung in Verbindung steht. Widerspricht die betroffene Person gegenüber der Ideen³ e.V. der Verarbeitung für Zwecke der Direktwerbung, so wird die Ideen³ e.V. die personenbezogenen Daten nicht mehr für diese Zwecke verarbeiten.</p>\n\n<p>Zudem hat die betroffene Person das Recht, aus Gründen, die sich aus ihrer besonderen Situation ergeben, gegen die sie betreffende Verarbeitung personenbezogener Daten, die bei der Ideen³ e.V. zu wissenschaftlichen oder historischen Forschungszwecken oder zu statistischen Zwecken gemäß Art. 89 Abs. 1 DS-GVO erfolgen, Widerspruch einzulegen, es sei denn, eine solche Verarbeitung ist zur Erfüllung einer im öffentlichen Interesse liegenden Aufgabe erforderlich.</p>\n\n<p>Zur Ausübung des Rechts auf Widerspruch kann sich die betroffene Person direkt jeden Mitarbeiter der Ideen³ e.V. oder einen anderen Mitarbeiter wenden. Der betroffenen Person steht es ferner frei, im Zusammenhang mit der Nutzung von Diensten der Informationsgesellschaft, ungeachtet der Richtlinie 2002/58/EG, ihr Widerspruchsrecht mittels automatisierter Verfahren auszuüben, bei denen technische Spezifikationen verwendet werden.</p>\n</li>\n<li><h4>h)    Automatisierte Entscheidungen im Einzelfall einschließlich Profiling</h4>\n<p>Jede von der Verarbeitung personenbezogener Daten betroffene Person hat das vom Europäischen Richtlinien- und Verordnungsgeber gewährte Recht, nicht einer ausschließlich auf einer automatisierten Verarbeitung — einschließlich Profiling — beruhenden Entscheidung unterworfen zu werden, die ihr gegenüber rechtliche Wirkung entfaltet oder sie in ähnlicher Weise erheblich beeinträchtigt, sofern die Entscheidung (1) nicht für den Abschluss oder die Erfüllung eines Vertrags zwischen der betroffenen Person und dem Verantwortlichen erforderlich ist, oder (2) aufgrund von Rechtsvorschriften der Union oder der Mitgliedstaaten, denen der Verantwortliche unterliegt, zulässig ist und diese Rechtsvorschriften angemessene Maßnahmen zur Wahrung der Rechte und Freiheiten sowie der berechtigten Interessen der betroffenen Person enthalten oder (3) mit ausdrücklicher Einwilligung der betroffenen Person erfolgt.</p>\n\n<p>Ist die Entscheidung (1) für den Abschluss oder die Erfüllung eines Vertrags zwischen der betroffenen Person und dem Verantwortlichen erforderlich oder (2) erfolgt sie mit ausdrücklicher Einwilligung der betroffenen Person, trifft die Ideen³ e.V. angemessene Maßnahmen, um die Rechte und Freiheiten sowie die berechtigten Interessen der betroffenen Person zu wahren, wozu mindestens das Recht auf Erwirkung des Eingreifens einer Person seitens des Verantwortlichen, auf Darlegung des eigenen Standpunkts und auf Anfechtung der Entscheidung gehört.</p>\n\n<p>Möchte die betroffene Person Rechte mit Bezug auf automatisierte Entscheidungen geltend machen, kann sie sich hierzu jederzeit an einen Mitarbeiter des für die Verarbeitung Verantwortlichen wenden.</p>\n\n</li>\n<li><h4>i)      Recht auf Widerruf einer datenschutzrechtlichen Einwilligung</h4>\n<p>Jede von der Verarbeitung personenbezogener Daten betroffene Person hat das vom Europäischen Richtlinien- und Verordnungsgeber gewährte Recht, eine Einwilligung zur Verarbeitung personenbezogener Daten jederzeit zu widerrufen.</p>\n\n<p>Möchte die betroffene Person ihr Recht auf Widerruf einer Einwilligung geltend machen, kann sie sich hierzu jederzeit an einen Mitarbeiter des für die Verarbeitung Verantwortlichen wenden.</p>\n\n</li>\n</ul>\n<h4>13. Datenschutz bei Bewerbungen und im Bewerbungsverfahren</h4>\n<p>Der für die Verarbeitung Verantwortliche erhebt und verarbeitet die personenbezogenen Daten von Bewerbern zum Zwecke der Abwicklung des Bewerbungsverfahrens. Die Verarbeitung kann auch auf elektronischem Wege erfolgen. Dies ist insbesondere dann der Fall, wenn ein Bewerber entsprechende Bewerbungsunterlagen auf dem elektronischen Wege, beispielsweise per E-Mail oder über ein auf der Internetseite befindliches Webformular, an den für die Verarbeitung Verantwortlichen übermittelt. Schließt der für die Verarbeitung Verantwortliche einen Anstellungsvertrag mit einem Bewerber, werden die übermittelten Daten zum Zwecke der Abwicklung des Beschäftigungsverhältnisses unter Beachtung der gesetzlichen Vorschriften gespeichert. Wird von dem für die Verarbeitung Verantwortlichen kein Anstellungsvertrag mit dem Bewerber geschlossen, so werden die Bewerbungsunterlagen zwei Monate nach Bekanntgabe der Absageentscheidung automatisch gelöscht, sofern einer Löschung keine sonstigen berechtigten Interessen des für die Verarbeitung Verantwortlichen entgegenstehen. Sonstiges berechtigtes Interesse in diesem Sinne ist beispielsweise eine Beweispflicht in einem Verfahren nach dem Allgemeinen Gleichbehandlungsgesetz (AGG).</p>\n\n<h4>14. Datenschutzbestimmungen zu Einsatz und Verwendung von Matomo</h4>\n<p>Der für die Verarbeitung Verantwortliche hat auf dieser Internetseite die Komponente Matomo integriert. Matomo ist ein Open-Source-Softwaretool zur Web-Analyse. Web-Analyse ist die Erhebung, Sammlung und Auswertung von Daten über das Verhalten von Besuchern von Internetseiten. Ein Web-Analyse-Tool erfasst unter anderem Daten darüber, von welcher Internetseite eine betroffene Person auf eine Internetseite gekommen ist (sogenannter Referrer), auf welche Unterseiten der Internetseite zugegriffen oder wie oft und für welche Verweildauer eine Unterseite betrachtet wurde. Eine Web-Analyse wird überwiegend zur Optimierung einer Internetseite und zur Kosten-Nutzen-Analyse von Internetwerbung eingesetzt.</p>\n\n<p>Die Software wird auf dem Server des für die Verarbeitung Verantwortlichen betrieben, die datenschutzrechtlich sensiblen Logdateien werden ausschließlich auf diesem Server gespeichert.</p>\n\n<p>Der Zweck der Matomo-Komponente ist die Analyse der Besucherströme auf unserer Internetseite. Der für die Verarbeitung Verantwortliche nutzt die gewonnenen Daten und Informationen unter anderem dazu, die Nutzung dieser Internetseite auszuwerten, um Online-Reports, welche die Aktivitäten auf unseren Internetseiten aufzeigen, zusammenzustellen.</p>\n\n<p>Matomo setzt ein Cookie auf dem informationstechnologischen System der betroffenen Person. Was Cookies sind, wurde oben bereits erläutert. Mit der Setzung des Cookies wird uns eine Analyse der Benutzung unserer Internetseite ermöglicht. Durch jeden Aufruf einer der Einzelseiten dieser Internetseite wird der Internetbrowser auf dem informationstechnologischen System der betroffenen Person automatisch durch die Matomo-Komponente veranlasst, Daten zum Zwecke der Online-Analyse an unseren Server zu übermitteln. Im Rahmen dieses technischen Verfahrens erhalten wir Kenntnis über personenbezogene Daten, wie der IP-Adresse der betroffenen Person, die uns unter anderem dazu dient, die Herkunft der Besucher und Klicks nachzuvollziehen.</p>\n\n<p>Mittels des Cookies werden personenbezogene Informationen, beispielsweise die Zugriffszeit, der Ort, von welchem ein Zugriff ausging und die Häufigkeit der Besuche auf unserer Internetseite gespeichert. Bei jedem Besuch unserer Internetseiten werden diese personenbezogenen Daten, einschließlich der IP-Adresse des von der betroffenen Person genutzten Internetanschlusses, an unseren Server übertragen. Diese personenbezogenen Daten werden durch uns gespeichert. Wir geben diese personenbezogenen Daten nicht an Dritte weiter.</p>\n\n<p>Die betroffene Person kann die Setzung von Cookies durch unsere Internetseite, wie oben bereits dargestellt, jederzeit mittels einer entsprechenden Einstellung des genutzten Internetbrowsers verhindern und damit der Setzung von Cookies dauerhaft widersprechen. Eine solche Einstellung des genutzten Internetbrowsers würde auch verhindern, dass Matomo ein Cookie auf dem informationstechnologischen System der betroffenen Person setzt. Zudem kann ein von Matomo bereits gesetzter Cookie jederzeit über einen Internetbrowser oder andere Softwareprogramme gelöscht werden.</p>\n\n<p>Ferner besteht für die betroffene Person die Möglichkeit, einer Erfassung der durch den Matomo erzeugten, auf eine Nutzung dieser Internetseite bezogenen Daten zu widersprechen und eine solche zu verhindern. Hierzu muss die betroffene Person in Ihrem Browser 'Do Not Track' einstellen.</p>\n\n<p>Mit der Setzung des Opt-Out-Cookies besteht jedoch die Möglichkeit, dass die Internetseiten des für die Verarbeitung Verantwortlichen für die betroffene Person nicht mehr vollumfänglich nutzbar sind.</p>\n\n<p>Weitere Informationen und die geltenden Datenschutzbestimmungen von Matomo können unter https://matomo.org/privacy/ abgerufen werden.</p>\n\n<h4>15. Rechtsgrundlage der Verarbeitung</h4>\n<p>Art. 6 I lit. a DS-GVO dient unserem Unternehmen als Rechtsgrundlage für Verarbeitungsvorgänge, bei denen wir eine Einwilligung für einen bestimmten Verarbeitungszweck einholen. Ist die Verarbeitung personenbezogener Daten zur Erfüllung eines Vertrags, dessen Vertragspartei die betroffene Person ist, erforderlich, wie dies beispielsweise bei Verarbeitungsvorgängen der Fall ist, die für eine Lieferung von Waren oder die Erbringung einer sonstigen Leistung oder Gegenleistung notwendig sind, so beruht die Verarbeitung auf Art. 6 I lit. b DS-GVO. Gleiches gilt für solche Verarbeitungsvorgänge die zur Durchführung vorvertraglicher Maßnahmen erforderlich sind, etwa in Fällen von Anfragen zur unseren Produkten oder Leistungen. Unterliegt unser Unternehmen einer rechtlichen Verpflichtung durch welche eine Verarbeitung von personenbezogenen Daten erforderlich wird, wie beispielsweise zur Erfüllung steuerlicher Pflichten, so basiert die Verarbeitung auf Art. 6 I lit. c DS-GVO. In seltenen Fällen könnte die Verarbeitung von personenbezogenen Daten erforderlich werden, um lebenswichtige Interessen der betroffenen Person oder einer anderen natürlichen Person zu schützen. Dies wäre beispielsweise der Fall, wenn ein Besucher in unserem Betrieb verletzt werden würde und daraufhin sein Name, sein Alter, seine Krankenkassendaten oder sonstige lebenswichtige Informationen an einen Arzt, ein Krankenhaus oder sonstige Dritte weitergegeben werden müssten. Dann würde die Verarbeitung auf Art. 6 I lit. d DS-GVO beruhen.\nLetztlich könnten Verarbeitungsvorgänge auf Art. 6 I lit. f DS-GVO beruhen. Auf dieser Rechtsgrundlage basieren Verarbeitungsvorgänge, die von keiner der vorgenannten Rechtsgrundlagen erfasst werden, wenn die Verarbeitung zur Wahrung eines berechtigten Interesses unseres Unternehmens oder eines Dritten erforderlich ist, sofern die Interessen, Grundrechte und Grundfreiheiten des Betroffenen nicht überwiegen. Solche Verarbeitungsvorgänge sind uns insbesondere deshalb gestattet, weil sie durch den Europäischen Gesetzgeber besonders erwähnt wurden. Er vertrat insoweit die Auffassung, dass ein berechtigtes Interesse anzunehmen sein könnte, wenn die betroffene Person ein Kunde des Verantwortlichen ist (Erwägungsgrund 47 Satz 2 DS-GVO).\n</p>\n\n<h4>16. Berechtigte Interessen an der Verarbeitung, die von dem Verantwortlichen oder einem Dritten verfolgt werden</h4>\n<p>Basiert die Verarbeitung personenbezogener Daten auf Artikel 6 I lit. f DS-GVO ist unser berechtigtes Interesse die Durchführung unserer Geschäftstätigkeit zugunsten des Wohlergehens all unserer Mitarbeiter und unserer Anteilseigner.</p>\n\n<h4>17. Dauer, für die die personenbezogenen Daten gespeichert werden</h4>\n<p>Das Kriterium für die Dauer der Speicherung von personenbezogenen Daten ist die jeweilige gesetzliche Aufbewahrungsfrist. Nach Ablauf der Frist werden die entsprechenden Daten routinemäßig gelöscht, sofern sie nicht mehr zur Vertragserfüllung oder Vertragsanbahnung erforderlich sind.</p>\n\n<h4>18. Gesetzliche oder vertragliche Vorschriften zur Bereitstellung der personenbezogenen Daten; Erforderlichkeit für den Vertragsabschluss; Verpflichtung der betroffenen Person, die personenbezogenen Daten bereitzustellen; mögliche Folgen der Nichtbereitstellung</h4>\n<p>Wir klären Sie darüber auf, dass die Bereitstellung personenbezogener Daten zum Teil gesetzlich vorgeschrieben ist (z.B. Steuervorschriften) oder sich auch aus vertraglichen Regelungen (z.B. Angaben zum Vertragspartner) ergeben kann.\nMitunter kann es zu einem Vertragsschluss erforderlich sein, dass eine betroffene Person uns personenbezogene Daten zur Verfügung stellt, die in der Folge durch uns verarbeitet werden müssen. Die betroffene Person ist beispielsweise verpflichtet uns personenbezogene Daten bereitzustellen, wenn unser Unternehmen mit ihr einen Vertrag abschließt. Eine Nichtbereitstellung der personenbezogenen Daten hätte zur Folge, dass der Vertrag mit dem Betroffenen nicht geschlossen werden könnte.\nVor einer Bereitstellung personenbezogener Daten durch den Betroffenen muss sich der Betroffene an einen unserer Mitarbeiter wenden. Unser Mitarbeiter klärt den Betroffenen einzelfallbezogen darüber auf, ob die Bereitstellung der personenbezogenen Daten gesetzlich oder vertraglich vorgeschrieben oder für den Vertragsabschluss erforderlich ist, ob eine Verpflichtung besteht, die personenbezogenen Daten bereitzustellen, und welche Folgen die Nichtbereitstellung der personenbezogenen Daten hätte.\n</p>\n\n<h4>19. Bestehen einer automatisierten Entscheidungsfindung</h4>\n<p>Als verantwortungsbewusstes Unternehmen verzichten wir auf eine automatische Entscheidungsfindung oder ein Profiling.</p>\n\n<p>Diese Datenschutzerklärung wurde durch den Datenschutzerklärungs-Generator der DGD Deutsche Gesellschaft für Datenschutz GmbH, die als <a href='https://dg-datenschutz.de/datenschutz-dienstleistungen/externer-datenschutzbeauftragter/'>Externer Datenschutzbeauftragter Erlangen</a> tätig ist, in Kooperation mit dem <a href='https://www.wbs-law.de/it-recht/datenschutzrecht/'>IT- und Datenschutzrecht Anwalt Christian Solmecke</a> erstellt.\n</p>\n\n"
   },
   "businesscardWidget": {
-    "showOnMap": "Mostrar en el mapa...."
+    "showOnMap": "Mostrar en el mapa..."
   },
   "mapWidget": {
-    "showLargeMap": "Abrir mapa grande...."
+    "showLargeMap": "Abrir mapa grande..."
   },
   "modal": {
     "locate": {
-      "inProgress": "Se busca su ubicación actual....",
-      "cancel": "romperse",
+      "inProgress": "Buscando tu ubicación actual...",
+      "cancel": "cancelar",
       "failed": "No se puede determinar la ubicación. La localización está deshabilitada en la configuración del navegador o del sistema, o el GPS no tiene recepción.",
-      "close": "terminar",
+      "close": "cerrar",
       "tryAgain": "intentarlo de nuevo"
     },
     "events": {
-      "text": "Si se trata de una conferencia, conferencia o festival - el mapa de mañana pronto incluirá eventos. También estamos planeando un calendario de eventos que mostrará y exportará los resultados. Ayuda a que esta función esté disponible pronto y participa en la campaña de recaudación de fondos en betterplace.org!",
-      "close": "terminar",
+      "text": "Actualmente no soportamos eventos.\n\n Sea una conferencia, taller o festival - el mapa del mañana pronto incluirá eventos. También estamos planeando un calendario de eventos que mostrará y exportará los resultados.\n\n¡Ayuda a que esta función esté disponible pronto y participa en la campaña de recaudación de fondos en betterplace.org!",
+      "close": "cerrar",
       "donate": "donar"
     },
     "embed": {
-      "findOutMore": "Más información sobre las opciones para compartir"
+      "findOutMore": "Más información sobre las opciones para compartir e integrar mapas en otros sitios web"
     }
   },
   "share": "Compartir",


### PR DESCRIPTION
Mainly a deep revamp of the ES translation, it also features a couple of updates and improvements in DE and EN.

- Punctuation and capitalizing corrections in all three languages.
- Added missing strings and removed old ones in EN

Also for ES:
- From _usted_ to _tú_ form
- Changed _de mañana_ to _del mañana_
- Removed a few localisms and anglicisms and follow standard expresions (_iniciar sesión_)
- Made some expressions more precise, easier to read and/or more loyal to the source strings.
- Improved a few wrong translations (_cancelar_, _guardar_)

As a result, the translations should be in a much cleaner state. Possible remaining errors in the original sources, but that is out of the scope of this PR.
